### PR TITLE
prettier-plugin-jsdoc: Fixes Markdown tables format and supports for the remarks tag

### DIFF
--- a/packages/public/prettier-plugin-jsdoc/src/fns/constants.js
+++ b/packages/public/prettier-plugin-jsdoc/src/fns/constants.js
@@ -50,6 +50,7 @@ const getTagsWithDescriptionAsName = () => [
   'examples',
   'file',
   'license',
+  'remarks',
   'summary',
   'throws',
   'todo',

--- a/packages/public/prettier-plugin-jsdoc/src/fns/prepareTagDescription.js
+++ b/packages/public/prettier-plugin-jsdoc/src/fns/prepareTagDescription.js
@@ -1,5 +1,5 @@
 const R = require('ramda');
-const { ensureSentence, hasValidProperty, isTag, isURL } = require('./utils');
+const { ensureSentence, hasValidProperty, isTag } = require('./utils');
 const { getTagsWithNameAsDescription } = require('./constants');
 const { get, provider } = require('./app');
 
@@ -20,11 +20,7 @@ const { get, provider } = require('./app');
  * @type {MakePropertyIntoSentenceFn}
  */
 const makePropertyIntoSentence = R.curry((property, tag) =>
-  R.compose(
-    R.assoc(property, R.__, tag),
-    R.when(R.complement(get(isURL)), get(ensureSentence)),
-    R.prop(property),
-  )(tag),
+  R.compose(R.assoc(property, R.__, tag), get(ensureSentence), R.prop(property))(tag),
 );
 
 /**

--- a/packages/public/prettier-plugin-jsdoc/src/fns/utils.js
+++ b/packages/public/prettier-plugin-jsdoc/src/fns/utils.js
@@ -324,6 +324,13 @@ const isURL = (text) =>
     /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/i,
     text,
   );
+/**
+ * Validates whether a text is Markdown table row (starts and ends with a pipe).
+ *
+ * @param {string} text  The text to validate.
+ * @returns {boolean}
+ */
+const isTableRow = (text) => isMatch(/^\s*\|.*?\|\s*$/, text);
 
 /**
  * Ensures a text starts with an uppercase and ends with a period.
@@ -333,7 +340,7 @@ const isURL = (text) =>
  */
 const ensureSentence = (text) =>
   R.when(
-    R.allPass([R.complement(get(isURL)), R.match(/\w\s*$/)]),
+    R.allPass([R.complement(get(isURL)), get(isMatch)(/[\w\.]\s*$/)]),
     R.compose(
       R.replace(/(\.)?(\s*)$/, (full, dot, padding) => `.${padding}`),
       R.replace(
@@ -359,6 +366,7 @@ module.exports.limitAdjacentRepetitions = limitAdjacentRepetitions;
 module.exports.hasValidProperty = hasValidProperty;
 module.exports.prefixLines = prefixLines;
 module.exports.splitLinesAndClean = splitLinesAndClean;
-module.exports.ensureSentence = ensureSentence;
 module.exports.isURL = isURL;
+module.exports.isTableRow = isTableRow;
+module.exports.ensureSentence = ensureSentence;
 module.exports.provider = provider('utils', module.exports);

--- a/packages/public/prettier-plugin-jsdoc/src/fns/utils.js
+++ b/packages/public/prettier-plugin-jsdoc/src/fns/utils.js
@@ -222,11 +222,6 @@ const getIndexOrFallback = R.curry((list, fallback, item) =>
  * Formats a list in order to remove items repeated items next to each other.
  *
  * @callback LimitAdjacentRepetitionsFn
- * @example
- *
- *   limitAdjacentRepetitions(R.equals('\n'), 1, ['hello', '\n', '\n', 'world']);
- *   // ['hello', '\n', 'world']
- *
  * @param {LimitAdjacentRepetitionsPredFn} pred   The function to validate if an item
  *                                                should be considered and start the
  *                                                count.
@@ -234,6 +229,11 @@ const getIndexOrFallback = R.curry((list, fallback, item) =>
  *                                                validated with predicate function can be
  *                                                adjacently repeated.
  * @param {Array}                          list   The list to format.
+ * @example
+ *
+ *   limitAdjacentRepetitions(R.equals('\n'), 1, ['hello', '\n', '\n', 'world']);
+ *   // ['hello', '\n', 'world']
+ *
  */
 
 /**
@@ -314,20 +314,6 @@ const splitLinesAndClean = R.curry((splitter, text) =>
 );
 
 /**
- * Ensures a text starts with an uppercase and ends with a period.
- *
- * @param {string} text  The text to format.
- * @returns {string}
- */
-const ensureSentence = (text) =>
-  R.compose(
-    R.replace(/(\.)?(\s*)$/, (full, dot, padding) => `.${padding}`),
-    R.replace(
-      /^(\s*)(\w)/,
-      (full, padding, letter) => `${padding}${letter.toUpperCase()}`,
-    ),
-  )(text);
-/**
  * Validates if a text is a valid URL.
  *
  * @param {string} text  The text to validate.
@@ -336,6 +322,25 @@ const ensureSentence = (text) =>
 const isURL = (text) =>
   isMatch(
     /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/i,
+    text,
+  );
+
+/**
+ * Ensures a text starts with an uppercase and ends with a period.
+ *
+ * @param {string} text  The text to format.
+ * @returns {string}
+ */
+const ensureSentence = (text) =>
+  R.when(
+    R.allPass([R.complement(get(isURL)), R.match(/\w\s*$/)]),
+    R.compose(
+      R.replace(/(\.)?(\s*)$/, (full, dot, padding) => `.${padding}`),
+      R.replace(
+        /^(\s*)(\w)/,
+        (full, padding, letter) => `${padding}${letter.toUpperCase()}`,
+      ),
+    ),
     text,
   );
 

--- a/packages/public/prettier-plugin-jsdoc/test/e2e/fixtures/markdown-01.fixture.js
+++ b/packages/public/prettier-plugin-jsdoc/test/e2e/fixtures/markdown-01.fixture.js
@@ -1,0 +1,99 @@
+//# input
+
+/**
+ * The mapping is as follows:
+ *
+ * | Prisma | GraphQL | Nexus `t` Helper | GraphQL Scalar Implementation |
+ * | ---------- | ---------- | ---- | -------------------------------------------------- |
+ * | `Json | `Json` | `json` | [JsonObject](https://github.com/Urigo/graphql-scalars#jsonobject) |
+ * | `DateTime` | `DateTime` | `datetime` | [DateTime](https://github.com/Urigo/graphql-scalars#datetime) |
+ *
+ * | Prisma     | GraphQL    | Nextus `t` Helper | GraphQL Scalar Implementation                                     |
+ * | ---------- | ---------- | ----------------- | ----------------------------------------------------------------- |
+ * | `Json      | `Json`     | `json`            | [JsonObject](https://github.com/Urigo/graphql-scalars#jsonobject) |
+ * | `DateTime` | `DateTime` | `datetime`        | [DateTime](https://github.com/Urigo/graphql-scalars#datetime)     |
+ *
+ * @example Some example.
+ */
+
+/**
+ * | Column A | Column B |
+ * | -------- | -------- |
+ * | Value A  | Value B  |
+ *
+ * @example Some example.
+ */
+
+/**
+ * Before table:
+ * | Column A | Column B |
+ * | -------- | -------- |
+ * | Value A  | Value B  |
+ *
+ * @example Some example.
+ */
+
+/**
+ * | Column A | Column B |
+ * | -------- | -------- |
+ * | Value A  | Value B  |
+ * After table.
+ *
+ * @example Some example.
+ */
+
+//# output
+
+/**
+ * The mapping is as follows:
+ *
+ * | Prisma | GraphQL | Nexus `t` Helper | GraphQL Scalar Implementation |
+ * | ---------- | ---------- | ---- | -------------------------------------------------- |
+ * | `Json | `Json` | `json` | [JsonObject](https://github.com/Urigo/graphql-scalars#jsonobject) |
+ * | `DateTime` | `DateTime` | `datetime` | [DateTime](https://github.com/Urigo/graphql-scalars#datetime) |
+ *
+ * | Prisma     | GraphQL    | Nextus `t` Helper | GraphQL Scalar Implementation                                     |
+ * | ---------- | ---------- | ----------------- | ----------------------------------------------------------------- |
+ * | `Json      | `Json`     | `json`            | [JsonObject](https://github.com/Urigo/graphql-scalars#jsonobject) |
+ * | `DateTime` | `DateTime` | `datetime`        | [DateTime](https://github.com/Urigo/graphql-scalars#datetime)     |
+ *
+ * @example
+ *
+ * Some example.
+ *
+ */
+
+/**
+ * | Column A | Column B |
+ * | -------- | -------- |
+ * | Value A  | Value B  |
+ *
+ * @example
+ *
+ * Some example.
+ *
+ */
+
+/**
+ * Before table:
+ * | Column A | Column B |
+ * | -------- | -------- |
+ * | Value A  | Value B  |
+ *
+ * @example
+ *
+ * Some example.
+ *
+ */
+
+/**
+ * | Column A | Column B |
+ * | -------- | -------- |
+ * | Value A  | Value B  |
+ * After table.
+ *
+ * @example
+ *
+ * Some example.
+ *
+ */

--- a/packages/public/prettier-plugin-jsdoc/test/e2e/fixtures/random-01.fixture.js
+++ b/packages/public/prettier-plugin-jsdoc/test/e2e/fixtures/random-01.fixture.js
@@ -39,6 +39,10 @@ const log = (name = 'batman', logger) => {};
  * @parent module:controllers
  */
 
+/**
+ * @remarks Some of the Prisma scalars do not have a natural standard representation in GraphQL. For these case Nexus Prisma generates code that references type names matching those scalar names in Prisma. Then, you are expected to define those custom scalar types in your GraphQL API.
+ */
+
 //# output
 
 /**
@@ -100,4 +104,11 @@ const log = (name = 'batman', logger) => {};
  * @typedef {StaticsControllerOptions & StaticsControllerWrapperOptionsProperties}
  * StaticsControllerWrapperOptions
  * @parent module:controllers
+ */
+
+/**
+ * @remarks Some of the Prisma scalars do not have a natural standard representation in
+ *          GraphQL. For these case Nexus Prisma generates code that references type names
+ *          matching those scalar names in Prisma. Then, you are expected to define those
+ *          custom scalar types in your GraphQL API.
  */

--- a/packages/public/prettier-plugin-jsdoc/test/unit/fns/splitText.test.js
+++ b/packages/public/prettier-plugin-jsdoc/test/unit/fns/splitText.test.js
@@ -112,4 +112,57 @@ describe('splitText', () => {
     // Then
     expect(result).toEqual(output);
   });
+
+  it('should keep a Markdown table unformatted', () => {
+    // Given
+    const input = [
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus\nlobortis',
+      'erat molestie posuere dictum. Integer libero justo, viverra\nquis efficitur',
+      'in, condimentum congue lorem.\n',
+      '| Column A | Column B |',
+      '| -------- | -------- |',
+      '| ValueA   | Value B  |',
+    ].join('\n');
+    const output = [
+      'Lorem ipsum dolor sit amet, consectetur adipiscing',
+      'elit. Phasellus lobortis erat molestie posuere',
+      'dictum. Integer libero justo, viverra quis',
+      'efficitur in, condimentum congue lorem.',
+      '',
+      '| Column A | Column B |',
+      '| -------- | -------- |',
+      '| ValueA   | Value B  |',
+    ];
+    let result = null;
+    // When
+    result = splitText(input, 50);
+    // Then
+    expect(result).toEqual(output);
+  });
+
+  it("should keep a Markdown table unformatted even when there's text after it", () => {
+    // Given
+    const input = [
+      '| Column A | Column B |',
+      '| -------- | -------- |',
+      '| ValueA   | Value B  |',
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus\nlobortis',
+      'erat molestie posuere dictum. Integer libero justo, viverra\nquis efficitur',
+      'in, condimentum congue lorem.',
+    ].join('\n');
+    const output = [
+      '| Column A | Column B |',
+      '| -------- | -------- |',
+      '| ValueA   | Value B  |',
+      'Lorem ipsum dolor sit amet, consectetur adipiscing',
+      'elit. Phasellus lobortis erat molestie posuere',
+      'dictum. Integer libero justo, viverra quis',
+      'efficitur in, condimentum congue lorem.',
+    ];
+    let result = null;
+    // When
+    result = splitText(input, 50);
+    // Then
+    expect(result).toEqual(output);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

- Fixes #7: It avoids formatting Markdown tables.
- Fixes #8: It supports `@remarks` tag formatting.

### How should it be tested manually?

Added e2e tests for both fixes, so...

```bash
npm test
# or
yarn test
```