### PR TITLE
fix(prettier-plugin-jsdoc): use comment-parser cjs file

### DIFF
--- a/packages/public/prettier-plugin-jsdoc/package.json
+++ b/packages/public/prettier-plugin-jsdoc/package.json
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "dependencies": {
-    "comment-parser": "^1.1.5",
+    "comment-parser": "^1.2.3",
     "prettier": "^2.3.2",
     "ramda": "0.27.1"
   },

--- a/packages/public/prettier-plugin-jsdoc/src/fns/getParsers.js
+++ b/packages/public/prettier-plugin-jsdoc/src/fns/getParsers.js
@@ -1,5 +1,5 @@
 const R = require('ramda');
-const { parse: commentParser } = require('comment-parser/lib');
+const { parse: commentParser } = require('comment-parser/lib/index.cjs');
 const babelParser = require('prettier/parser-babel');
 const flowParser = require('prettier/parser-flow');
 const tsParser = require('prettier/parser-typescript');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,10 +2299,10 @@ comment-parser@1.1.6-beta.3:
   resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.1.6-beta.3.tgz#66df48fa6e8a10d9e31016613491b78075fe3065"
   integrity sha512-LkPpVUx533rkxrkgphwWo0u6A3Vn9/fa8biHo2mrL6NUKPL6ubnF1P7NTm/M9i/rUvQ/mDxVqOVlmqy5uNUmVw==
 
-comment-parser@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.1.5.tgz#453627ef8f67dbcec44e79a9bd5baa37f0bce9b2"
-  integrity sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==
+comment-parser@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.2.3.tgz#303a7eb99c9b2632efd594e183ccbd32042caf69"
+  integrity sha512-vnqDwBSXSsdAkGS5NjwMIPelE47q+UkEgWKHvCDNhVIIaQSUFY6sNnEYGzdoPGMdpV+7KR3ZkRd7oyWIjtuvJg==
 
 compare-func@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### What does this PR do?

When `comment-parser` released to `1.1.6-beta.2`, they changed the commonjs files to `.cjs`, and since the version range was `1.1.5` and the version was SemVer compatible... it completely broke the plugin :P.

This PR fixed the import in order to use the new `.cjs` file.

Fixes #17 

### How should it be tested manually?

```bash
npm test
# or
yarn test
```