### PR TITLE
fix(prettier-plugin-jsdoc): update comment-parser

### DIFF
--- a/packages/public/prettier-plugin-jsdoc/package.json
+++ b/packages/public/prettier-plugin-jsdoc/package.json
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "dependencies": {
-    "comment-parser": "1.1.5",
+    "comment-parser": "^1.2.3",
     "prettier": "^2.3.2",
     "ramda": "0.27.1"
   },

--- a/packages/public/prettier-plugin-jsdoc/src/fns/getParsers.js
+++ b/packages/public/prettier-plugin-jsdoc/src/fns/getParsers.js
@@ -1,5 +1,5 @@
 const R = require('ramda');
-const { parse: commentParser } = require('comment-parser/lib');
+const { parse: commentParser } = require('comment-parser');
 const babelParser = require('prettier/parser-babel');
 const flowParser = require('prettier/parser-flow');
 const tsParser = require('prettier/parser-typescript');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2294,12 +2294,7 @@ commander@^7.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
-comment-parser@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.1.5.tgz#453627ef8f67dbcec44e79a9bd5baa37f0bce9b2"
-  integrity sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==
-
-comment-parser@1.2.3:
+comment-parser@1.2.3, comment-parser@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.2.3.tgz#303a7eb99c9b2632efd594e183ccbd32042caf69"
   integrity sha512-vnqDwBSXSsdAkGS5NjwMIPelE47q+UkEgWKHvCDNhVIIaQSUFY6sNnEYGzdoPGMdpV+7KR3ZkRd7oyWIjtuvJg==


### PR DESCRIPTION
### What does this PR do?

Updates the `comment-pareser` dependency to its latest version and fixes the import path, as suggested by the lib maintainers.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
