### PR TITLE
New package: extend-promise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,15 @@ jobs:
           flag-name: public-deep-assign
           path-to-lcov: ./packages/public/deep-assign/coverage/lcov.info
           base-path: ./packages/public/deep-assign
+      - name: Coveralls for public/extend-promise
+        if: ${{ matrix.node == '14' }}
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
+          flag-name: public-extend-promise
+          path-to-lcov: ./packages/public/extend-promise/coverage/lcov.info
+          base-path: ./packages/public/extend-promise
 
   finish:
       needs: build

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "prettier --write"
     ],
     "*.{ts,tsx,js}": [
-      "eslint --max-warnings 0 --fix"
+      "eslint"
     ]
   },
   "scripts": {

--- a/packages/public/extend-promise/.eslintrc.js
+++ b/packages/public/extend-promise/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: 'tsconfig.json',
+    sourceType: 'module',
+  },
+  plugins: ['@homer0'],
+  extends: ['plugin:@homer0/node-typescript-with-prettier'],
+  ignorePatterns: ['.eslintrc.js', 'dist/'],
+};

--- a/packages/public/extend-promise/.jestrc.js
+++ b/packages/public/extend-promise/.jestrc.js
@@ -1,0 +1,18 @@
+const path = require('path');
+
+/**
+ * @type {import('ts-jest').InitialOptionsTsJest}
+ */
+module.exports = {
+  preset: 'ts-jest',
+  automock: true,
+  collectCoverage: true,
+  testPathIgnorePatterns: ['/node_modules/'],
+  unmockedModulePathPatterns: ['/node_modules/'],
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: path.join(__dirname, 'tests', 'tsconfig.json'),
+    },
+  },
+};

--- a/packages/public/extend-promise/README.md
+++ b/packages/public/extend-promise/README.md
@@ -1,0 +1,96 @@
+# 💫 Extend promise
+
+Extend a `Promise` by injecting custom properties using a `Proxy`. The custom properties will be available on the promise chain no matter how many `then`s, `catch`s or `finally`s are added.
+
+## 🍿 Usage
+
+> If you are wondering why I built this, go to the [Motivation](#motivation) section.
+
+- ⚙️ [Examples](#%EF%B8%8F-examples)
+- 🤘 [Development](#-development)
+
+### ⚙️ Examples
+
+> This function can be used with any kind of promises, but the example focuses on requests because, nowadays, they are the most common context for promises.
+
+Let's say you have a function that makes a request and you want to be able to return a way to abort it at any point. You can use [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) and
+an [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) to do it, but you can't return just the promise, you need to return the controller, or at least its `abort` method:
+
+```js
+const makeTheRequest = () => {
+  const controller = new AbortController();
+  const req = fetch('https://...', {
+    signal: controller.signal,
+  });
+
+  return { req, controller };
+};
+```
+
+It looks good, but if the function is called from a service or somewhere that is not the actual implementation, you'll need to keep track of both the `Promise` and the `controller`.
+
+You could _monkey patch_ the `abort` method to the `Promise`:
+
+```js
+const makeTheRequest = () => {
+  const controller = new AbortController();
+  const req = fetch('https://...', {
+    signal: controller.signal,
+  });
+  req.abort = controller.abort.bind(this);
+  return req;
+};
+```
+
+But there's a problem: the moment a `.then`/`.catch`/`.finally` is added to that `Promise`, a new one is generated, and the patch goes away.
+
+This is where `extend-promise` can help you: Either the `controller` or the `abort` method can be added to the chain and the customization will be available no matter how many `.then`s are added:
+
+```js
+import { extendPromise } from '@homer0/extend-promise';
+
+const makeTheRequest = () => {
+  const controller = new AbortController();
+  const req = fetch('https://...', {
+    signal: controller.signal,
+  });
+
+  return extendPromise(req, {
+    abort: controller.abort.bind(this),
+  });
+};
+```
+
+And there you go! You can now receive the request `Promise` and abort it if needed:
+
+```js
+// Make the request
+const req = makeTheRequest()
+.then((response) => response.json())
+.catch((error) => {
+  if (error.name === 'AbortError') {
+    console.log('to late...');
+  }
+  ...
+});
+
+// Abort it if takes more than one second.
+setTimeout(() => req.abort(), 1000);
+```
+
+## 🤘 Development
+
+As this project is part of the `packages` monorepo, it requires Yarn, and some of the tooling, like ESLint and Husky, are installed on the root's `package.json`.
+
+### Yarn tasks
+
+| Task    | Description          |
+| ------- | -------------------- |
+| `test`  | Runs the unit tests. |
+| `build` | Bundles the project. |
+
+## Motivation
+
+This used to be part of the [`wootils`](https://www.npmjs.com/package/wootils), my personal lib of utilities, but I decided to extract them into individual packages, as part of the `packages` monorepo, and take the oportunity to migrate them to TypeScript.
+
+Now, the example in this same `README` is the reason I built it: I wanted the `AbortController` to be available on the `Promise` chain.

--- a/packages/public/extend-promise/package.json
+++ b/packages/public/extend-promise/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@homer0/extend-promise",
+  "description": "Extends a promise with custom properties",
+  "version": "0.0.0-development",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/homer0/packages.git",
+    "directory": "packages/public/extend-promise"
+  },
+  "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
+  "license": "MIT",
+  "keywords": [
+    "promise",
+    "custom",
+    "utility",
+    "wootils",
+    "javascript"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "build/"
+  ],
+  "devDependencies": {
+    "@types/jest": "^28.1.1",
+    "jest": "^28.1.1",
+    "ts-jest": "^28.0.4",
+    "tsup": "^6.1.2",
+    "typescript": "^4.7.3"
+  },
+  "engine-strict": true,
+  "engines": {
+    "node": ">=14"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "test": "jest -c ./.jestrc.js",
+    "build": "tsup src/index.ts",
+    "prepublishOnly": "npm run build"
+  }
+}

--- a/packages/public/extend-promise/src/index.ts
+++ b/packages/public/extend-promise/src/index.ts
@@ -1,0 +1,146 @@
+type ExtractGeneric<Type> = Type extends Promise<infer X> ? X : never;
+
+type ExtendedPromise<T extends Promise<unknown>, P, V = ExtractGeneric<T>> = Omit<
+  T,
+  'then' | 'catch' | 'finally'
+> &
+  P & {
+    then: (...args: Parameters<T['then']>) => ExtendedPromise<Promise<V>, P>;
+    catch: (...args: Parameters<T['catch']>) => ExtendedPromise<Promise<V>, P>;
+    finally: (...args: Parameters<T['finally']>) => ExtendedPromise<Promise<V>, P>;
+  };
+type GenericFn = (...args: unknown[]) => unknown;
+type ExtendedFn<F extends GenericFn, P> = F & P;
+
+/**
+ * Helper class that creates a proxy for a {@link Promise} in order to add custom
+ * properties.
+ *
+ * The only reason this class exists is so it can "scope" the necessary methods to extend
+ * {@link Promise} and avoid workarounds in order to declare them, as they need to call
+ * themselves recursively.
+ */
+class PromiseExtender<T extends Promise<unknown>, P extends Record<string, unknown>> {
+  /**
+   * The proxied promise.
+   */
+  readonly promise: ExtendedPromise<T, P>;
+  /**
+   * @param promise     The promise to extend.
+   * @param properties  A dictionary of custom properties to _inject_ in the promise
+   *                    chain.
+   */
+  constructor(promise: T, properties: P) {
+    this.promise = this.extend(promise, properties);
+  }
+  /**
+   * The method that actually extends a promise: it creates a proxy of the promise in
+   * order to intercept the getters so it can return the custom properties if requested,
+   * and return new proxies when `then`, `catch` and `finally` are called; the reason new
+   * proxies are created is because those methods return new promises, and without being
+   * proxied, the custom properties would be lost.
+   *
+   * @param promise     The promise to proxy.
+   * @param properties  A dictionary of custom properties to _inject_ in the promise
+   *                    chain.
+   * @throws {Error} If `promise` is not a valid instance of {@link Promise}.
+   * @throws {Error} If `properties` is not an object or if it doesn't have any
+   *                 properties.
+   */
+  extend(promise: T, properties: P): ExtendedPromise<T, P> {
+    if (!(promise instanceof Promise)) {
+      throw new Error("'promise' must be a valid Promise instance");
+    }
+
+    if (!properties || !Object.keys(properties).length) {
+      throw new Error("'properties' must be an object with at least one key");
+    }
+
+    const extended = new Proxy(promise, {
+      /**
+       * This is a trap for when something is trying to read/access a property for the
+       * promise.
+       * The function first validates if it's one of the functions
+       * (`then`/`catch`/`finally`) in order to return a proxied function; then, if it's
+       * another function (one that doesn't return another promise), it just calls the
+       * original; finally, before doing a fallback to the original promise, it checks if
+       * it's one of the custom properties that exented the promise.
+       *
+       * @param target  The original promise.
+       * @param name    The name of the property.
+       */
+      get: (target, name) => {
+        const targetKey = name as keyof typeof target;
+        if (
+          typeof name === 'string' &&
+          ['then', 'catch', 'finally'].includes(name) &&
+          name in target
+        ) {
+          const fn = target[targetKey] as unknown as GenericFn;
+          return this.extendFunction(fn.bind(target), properties);
+        }
+
+        if (name in target) {
+          const possibleFn = target[targetKey] as unknown as Record<string, unknown>;
+          // eslint-disable-next-line dot-notation
+          if (typeof possibleFn['bind'] === 'function') {
+            // eslint-disable-next-line dot-notation
+            return possibleFn['bind'](target);
+          }
+        }
+
+        const key = name as keyof P;
+        return properties[key];
+      },
+    });
+
+    return extended as ExtendedPromise<T, P>;
+  }
+  /**
+   * Creates a proxy for a promise function (`then`/`catch`/`finally`) so the returned
+   * promise can also be extended.
+   *
+   * @param fn          The promise function to proxy.
+   * @param properties  A dictionary of custom properties to _inject_ in the promise
+   *                    chain.
+   */
+  protected extendFunction<F extends GenericFn>(fn: F, properties: P): ExtendedFn<F, P> {
+    return new Proxy(fn, {
+      /**
+       * This is a trap for when a function gets called (remember this gets used for
+       * `then`/
+       * `catch`/`finally`); it processes the result using the oringinal function and
+       * since promise methods return a promise, instead of returning the original result,
+       * it returns an _extended_ version of it.
+       *
+       * @param target   The original function.
+       * @param thisArg  The promise the function belongs to.
+       * @param args     The list of arguments sent to the trap.
+       */
+      apply: (target, thisArg, args) => {
+        const value = target.bind(thisArg)(...args);
+        return this.extend(value as T, properties);
+      },
+    }) as ExtendedFn<F, P>;
+  }
+}
+
+/**
+ * Extends a {@link Promise} by injecting custom properties using a {@link Proxy}. The
+ * custom properties will be available on the promise chain no matter how many `then`s,
+ * `catch`s or `finally`s are added.
+ *
+ * @param promise     The promise to extend.
+ * @param properties  A dictionary of custom properties to _inject_ in the promise
+ *                    chain.
+ * @throws {Error} If `promise` is not a valid instance of {@link Promise}.
+ * @throws {Error} If `properties` is not an object or if it doesn't have any
+ *                 properties.
+ */
+export const extendPromise = <
+  T extends Promise<unknown>,
+  P extends Record<string, unknown>,
+>(
+  promise: T,
+  properties: P,
+): ExtendedPromise<T, P> => new PromiseExtender(promise, properties).promise;

--- a/packages/public/extend-promise/tests/.eslintrc.js
+++ b/packages/public/extend-promise/tests/.eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: 'tsconfig.json',
+    sourceType: 'module',
+  },
+  plugins: ['@homer0'],
+  extends: [
+    'plugin:@homer0/node-typescript-with-prettier',
+    'plugin:@homer0/jest-with-prettier',
+  ],
+  ignorePatterns: ['.eslintrc.js'],
+};

--- a/packages/public/extend-promise/tests/index.test.ts
+++ b/packages/public/extend-promise/tests/index.test.ts
@@ -1,0 +1,68 @@
+jest.unmock('../src');
+
+import { extendPromise } from '../src';
+
+describe('extendPromise', () => {
+  it('should throw an error when called with anything but a promise', () => {
+    // Given/When/Then
+    // @ts-expect-error - we're testing the error
+    expect(() => extendPromise()).toThrow(/'promise' must be a valid Promise instance/i);
+  });
+
+  it('should throw an error when called without extended properties', () => {
+    // Given/When/Then
+    // @ts-expect-error - we're testing the error
+    expect(() => extendPromise(Promise.resolve())).toThrow(
+      /'properties' must be an object with at least one key/i,
+    );
+  });
+
+  it('should throw an error when called with an empty object', () => {
+    // Given/When/Then
+    expect(() => extendPromise(Promise.resolve(), {})).toThrow(
+      /'properties' must be an object with at least one key/i,
+    );
+  });
+
+  it('should extend a promise chain', async () => {
+    // Given
+    const promise = Promise.resolve(0);
+    const properties = {
+      custom: 2509,
+    };
+    // When
+    let sut = extendPromise(promise, properties);
+    const valueAfterCreation = sut.custom;
+    sut = sut.then(() => 1);
+    const valueAfterFirstThen = sut.custom;
+    sut = sut.then(() => 2);
+    const valueAfterSecondThen = sut.custom;
+    sut = sut.catch((error) => Promise.reject(error));
+    const valueAfterCatch = sut.custom;
+    await sut;
+    // Then
+    expect(sut).toBeInstanceOf(Promise);
+    expect(sut.custom).toBe(properties.custom);
+    expect(valueAfterCreation).toBe(properties.custom);
+    expect(valueAfterFirstThen).toBe(properties.custom);
+    expect(valueAfterSecondThen).toBe(properties.custom);
+    expect(valueAfterCatch).toBe(properties.custom);
+  });
+
+  it('should use a native method even if a property tries to overwrite it', async () => {
+    // Given
+    const promise = Promise.resolve();
+    const properties = {
+      toString: jest.fn(),
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = extendPromise(promise, properties);
+    result = sut.toString();
+    await sut;
+    // Then
+    expect(result).toEqual(promise.toString());
+    expect(properties.toString).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/public/extend-promise/tests/tsconfig.json
+++ b/packages/public/extend-promise/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@homer0/tsconfig/tsconfig.node.json",
+  "compilerOptions": {
+    "types": ["jest"],
+    "strict": true,
+    "noImplicitAny": true
+  },
+  "include": ["./"]
+}

--- a/packages/public/extend-promise/tsconfig.json
+++ b/packages/public/extend-promise/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@homer0/tsconfig/tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "emitDecoratorMetadata": false,
+    "incremental": false
+  },
+  "include": ["src/**/*.ts", "tsup.config.ts"]
+}

--- a/packages/public/extend-promise/tsup.config.ts
+++ b/packages/public/extend-promise/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  sourcemap: true,
+  clean: true,
+  format: ['esm', 'cjs'],
+  legacyOutput: true,
+  dts: true,
+});


### PR DESCRIPTION
### What does this PR do?

It migrates the `extendPromise` module from `wootils` into its own package.

I also took the opportunity to move it to TypeScript.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```