### PR TITLE
New package: package-info

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,15 @@ jobs:
           flag-name: public-env-utils
           path-to-lcov: ./packages/public/env-utils/coverage/lcov.info
           base-path: ./packages/public/env-utils
+      - name: Coveralls for public/package-info
+        if: ${{ matrix.node == '14' }}
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
+          flag-name: public-package-info
+          path-to-lcov: ./packages/public/package-info/coverage/lcov.info
+          base-path: ./packages/public/package-info
 
   finish:
       needs: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: yarn --frozen-lockfile
       - run: yarn lint:all
-      - run: yarn build --scope @homer0/jimple --stream
-      - run: yarn build --scope @homer0/object-utils --stream
       - run: yarn build
       - run: yarn test
       - name: Coveralls (unit) for public/prettier-plugin-jsdoc

--- a/packages/public/env-utils/package.json
+++ b/packages/public/env-utils/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "keywords": [
     "node",
-    "path",
+    "environment",
     "utility",
     "wootils",
     "javascript"

--- a/packages/public/jimple/src/helpers/index.ts
+++ b/packages/public/jimple/src/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from './injectHelper';
 export * from './provider';
 export * from './providerCreator';
 export * from './providers';

--- a/packages/public/jimple/src/helpers/injectHelper.ts
+++ b/packages/public/jimple/src/helpers/injectHelper.ts
@@ -1,0 +1,124 @@
+import type { Jimple } from '../jimple';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- They are dynamically extended.
+type GenericDict = Record<any, any>;
+/**
+ * A helper that reusable services can use to resolve dependencies in constructors and/or
+ * providers.
+ *
+ * @template InjectDictionary  A dictionary of the dependencies and their types.
+ * @template InjectKey         The literal type of the dictionary types.
+ */
+export class InjectHelper<
+  InjectDictionary extends GenericDict,
+  InjectKey = keyof InjectDictionary,
+> {
+  /**
+   * This method is meant to be used to validate the dependencies a service receives, and
+   * needs.
+   * It will check on the received dependencies, if a specific dependency exists, it will
+   * return it, otherwise, it will create a new instance.
+   *
+   * @param dependencies  The dependencies received by the implementation.
+   * @param key           The key of the dependency to validate.
+   * @param init          A function to create a dependency in case it doesn't exist in
+   *                      the dictionary.
+   * @returns An instance of the dependency.
+   * @template DepKey   The literal key of the dependency to validate.
+   * @template DepType  The type of the dependency, obtained from the dictionary sent
+   *                    to the constructor.
+   * @example
+   *
+   *   type Dependencies = {
+   *     dep: string;
+   *   };
+   *   const helper = new InjectHelper<Dependencies>();
+   *
+   *   type MyServiceOptions = {
+   *     inject?: Partial<Dependencies>;
+   *   };
+   *   const myService = ({ inject = {} }: MyServiceOptions) => {
+   *     const dep = helper.get(inject, 'dep', () => 'default');
+   *     console.log('dep:', dep);
+   *   };
+   *
+   */
+  get<DepKey extends InjectKey, DepType = InjectDictionary[DepKey]>(
+    dependencies: Partial<InjectDictionary>,
+    key: InjectKey,
+    init: () => DepType,
+  ): DepType {
+    const existing = dependencies[key];
+    if (typeof existing !== 'undefined') {
+      return existing!;
+    }
+
+    return init();
+  }
+  /**
+   * This is meant to be used in a provider creator to resolve dependencies' names sent as
+   * options. For each dependency, the method will first check if a new name was
+   * specified, and try to get it with that name, otherwise, it will try to get it with
+   * the default name, and if it doesn't exist, it will just keep it as `undefined` and
+   * expect the service implements {@link InjectHelper.get} to ensure the dependency.
+   *
+   * @param dependencies  The dependencies needed by the service.
+   * @param container     A reference to the Jimple container.
+   * @param inject        A dictionary of dependencies names.
+   * @returns A dictionary of dependencies to send to the service.
+   * @template DepKey     The literal key of the dependencies to validate.
+   * @template Container  The type of the Jimple container.
+   * @example
+   *
+   *   type Dependencies = {
+   *     dep: string;
+   *   };
+   *   const helper = new InjectHelper<Dependencies>();
+   *
+   *   type MyProviderOptions = {
+   *     services?: {
+   *       [key in keyof Dependencies]?: string;
+   *     };
+   *   };
+   *
+   *   const myProvider = providerCreator(
+   *     ({ services = {} }: MyProviderOptions) =>
+   *       (container) => {
+   *         container.set('myService', () => {
+   *           const inject = helper.resolve(['dep'], container, services);
+   *           return myService({ inject });
+   *         });
+   *       },
+   *   );
+   *
+   */
+  resolve<DepKey extends InjectKey, Container extends Jimple>(
+    dependencies: DepKey[],
+    container: Container,
+    inject: Partial<Record<keyof InjectDictionary, string>>,
+  ): Partial<InjectDictionary> {
+    const result = dependencies.reduce<Partial<InjectDictionary>>((acc, key) => {
+      if (inject[key]) {
+        acc[key] = container.get<InjectDictionary[typeof key]>(inject[key]!);
+        return acc;
+      }
+
+      const keyStr = key as unknown as string;
+      if (container.has(keyStr)) {
+        acc[key] = container.get<InjectDictionary[typeof key]>(keyStr);
+        return acc;
+      }
+
+      return acc;
+    }, {});
+
+    return result;
+  }
+}
+/**
+ * Shorthand for `new InjectHelper()`.
+ *
+ * @returns A new instance of {@link InjectHelper}.
+ */
+export const injectHelper = <InjectDictionary extends GenericDict>() =>
+  new InjectHelper<InjectDictionary>();

--- a/packages/public/jimple/tests/helpers/injectHelper.test.ts
+++ b/packages/public/jimple/tests/helpers/injectHelper.test.ts
@@ -1,0 +1,71 @@
+import { Jimple } from '../../src/jimple';
+import { InjectHelper, injectHelper } from '../../src/helpers';
+
+describe('InjectHelper', () => {
+  describe('class', () => {
+    it('should be initialized', () => {
+      // Given/When
+      const sut = new InjectHelper();
+      // Then
+      expect(sut).toBeInstanceOf(InjectHelper);
+    });
+
+    it('should return a dependency that already exists', () => {
+      // Given
+      type Dependencies = {
+        dep: string;
+      };
+      const dependency = 'hello-world';
+      // When
+      const sut = new InjectHelper<Dependencies>();
+      const result = sut.get({ dep: dependency }, 'dep', () => '');
+      // Then
+      expect(result).toBe(dependency);
+    });
+
+    it("should create a dependency that doesn't exists", () => {
+      // Given
+      type Dependencies = {
+        dep: string;
+      };
+      const dependency = 'hello-world';
+      // When
+      const sut = new InjectHelper<Dependencies>();
+      const result = sut.get({}, 'dep', () => dependency);
+      // Then
+      expect(result).toBe(dependency);
+    });
+
+    it('should resolve dependencies from the container', () => {
+      // Given
+      type Dependencies = {
+        depOne: string;
+        depTwo: number;
+        depThree: string[];
+      };
+      const depOne = 'hello-world';
+      const depTwo = 2509;
+      const container = new Jimple({
+        depOne,
+        myDepTwo: depTwo,
+      });
+      // When
+      const sut = new InjectHelper<Dependencies>();
+      const result = sut.resolve(['depOne', 'depTwo', 'depThree'], container, {
+        depTwo: 'myDepTwo',
+      });
+      // Then
+      expect(result).toEqual({
+        depOne,
+        depTwo,
+      });
+    });
+  });
+
+  describe('shorthand', () => {
+    it('should have a shorthand function', () => {
+      // Given/When/Then
+      expect(injectHelper()).toBeInstanceOf(InjectHelper);
+    });
+  });
+});

--- a/packages/public/package-info/.eslintrc.js
+++ b/packages/public/package-info/.eslintrc.js
@@ -12,7 +12,13 @@ module.exports = {
     'node/no-extraneous-import': [
       'error',
       {
-        allowModules: ['@homer0/jimple'],
+        allowModules: ['@homer0/jimple', '@homer0/deferred', '@homer0/path-utils'],
+      },
+    ],
+    'node/no-missing-import': [
+      'error',
+      {
+        allowModules: ['package-json-type'],
       },
     ],
   },

--- a/packages/public/package-info/.eslintrc.js
+++ b/packages/public/package-info/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: 'tsconfig.json',
+    sourceType: 'module',
+  },
+  plugins: ['@homer0'],
+  extends: ['plugin:@homer0/node-typescript-with-prettier'],
+  ignorePatterns: ['.eslintrc.js', 'dist/'],
+  rules: {
+    'node/no-extraneous-import': [
+      'error',
+      {
+        allowModules: ['@homer0/jimple'],
+      },
+    ],
+  },
+};

--- a/packages/public/package-info/.jestrc.js
+++ b/packages/public/package-info/.jestrc.js
@@ -1,0 +1,18 @@
+const path = require('path');
+
+/**
+ * @type {import('ts-jest').InitialOptionsTsJest}
+ */
+module.exports = {
+  preset: 'ts-jest',
+  automock: true,
+  collectCoverage: true,
+  testPathIgnorePatterns: ['/node_modules/'],
+  unmockedModulePathPatterns: ['/node_modules/', 'jimple', 'path-utils', 'deferred'],
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: path.join(__dirname, 'tests', 'tsconfig.json'),
+    },
+  },
+};

--- a/packages/public/package-info/README.md
+++ b/packages/public/package-info/README.md
@@ -1,0 +1,33 @@
+# 📦 Package info
+
+A tiny service that reads the contents of the project's `package.json`, sync & async.
+
+## 🍿 Usage
+
+- ⚙️ [Examples](#%EF%B8%8F-examples)
+- 🤘 [Development](#-development)
+
+### ⚙️ Example
+
+```ts
+import { packageInfo } from '@homer0/package-info';
+
+const pkg = packageInfo();
+
+// ...
+
+const info = await pkg.get();
+// or
+const info = pkg.getSync();
+```
+
+### 🤘 Development
+
+As this project is part of the `packages` monorepo, it requires Yarn, and some of the tooling, like ESLint and Husky, are installed on the root's `package.json`.
+
+#### Yarn tasks
+
+| Task    | Description          |
+| ------- | -------------------- |
+| `test`  | Runs the unit tests. |
+| `build` | Bundles the project. |

--- a/packages/public/package-info/package.json
+++ b/packages/public/package-info/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@homer0/package-info",
+  "description": "Gets the content of the project's package.json",
+  "version": "0.0.0-development",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/homer0/packages.git",
+    "directory": "packages/public/package-info"
+  },
+  "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
+  "license": "MIT",
+  "keywords": [
+    "node",
+    "packagejson",
+    "utility",
+    "wootils",
+    "javascript"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist/"
+  ],
+  "devDependencies": {
+    "@types/jest": "^28.1.1",
+    "jest": "^28.1.1",
+    "package-json-type": "^1.0.3",
+    "ts-jest": "^28.0.4",
+    "tsup": "^6.1.2",
+    "typescript": "^4.7.3"
+  },
+  "engine-strict": true,
+  "engines": {
+    "node": ">=14"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "test": "jest -c ./.jestrc.js",
+    "build": "tsup src/index.ts",
+    "prepublishOnly": "npm run build"
+  }
+}

--- a/packages/public/package-info/src/index.ts
+++ b/packages/public/package-info/src/index.ts
@@ -1,0 +1,143 @@
+import * as fsSync from 'fs';
+import * as fsPromises from 'fs/promises';
+import type { IPackageJson } from 'package-json-type';
+import { pathUtils, type PathUtils } from '@homer0/path-utils';
+import { deferred, type DeferredPromise } from '@homer0/deferred';
+import { providerCreator } from '@homer0/jimple';
+/**
+ * The dictionary of dependencies that need to be injected in {@link PackageInfo}.
+ */
+type PackageInfoInjectOptions = {
+  /**
+   * The service that creates the path relative to the project root.
+   */
+  pathUtils: PathUtils;
+};
+/**
+ * The list of services the provider will check when registering the service.
+ */
+const INJECT_NAMES: Array<keyof PackageInfoInjectOptions> = ['pathUtils'];
+/**
+ * The options for the service constructor.
+ */
+export type PackageInfoOptions = {
+  /**
+   * A dictionary with the dependency injections for the service. If one or more are not
+   * provided, the service will create new instances.
+   */
+  inject?: Partial<PackageInfoInjectOptions>;
+};
+/**
+ * A small service that reads the contents of the implementation's package.json file.
+ */
+export class PackageInfo {
+  /**
+   * A deferred promise that resolves when the package.json file is read. It will be
+   * `undefined` if the file hasn't been read yet, or the contents are already saved in
+   * the service.
+   */
+  protected defer?: DeferredPromise<IPackageJson>;
+  /**
+   * This property will store the contents of the file once it is read.
+   */
+  protected contents?: IPackageJson;
+  /**
+   * The absolute path to the package.json file.
+   */
+  protected filepath: string;
+  constructor(options: PackageInfoOptions = {}) {
+    const { inject = {} } = options;
+    const usePathUtils = inject.pathUtils || pathUtils();
+    this.filepath = usePathUtils.join('package.json');
+  }
+  /**
+   * Gets the contents of the implementation's package.json file.
+   */
+  async get(): Promise<Readonly<IPackageJson>> {
+    if (this.contents) return this.contents;
+    if (this.defer) return this.defer.promise;
+
+    this.defer = deferred<IPackageJson>();
+    const packageJson = await fsPromises.readFile(this.filepath, 'utf8');
+    return this.updateContents(packageJson);
+  }
+  /**
+   * Synchronously gets the contents of the implementation's package.json file.
+   */
+  getSync(): Readonly<IPackageJson> {
+    if (this.contents) return this.contents;
+
+    const packageJson = fsSync.readFileSync(this.filepath, 'utf8');
+    return this.updateContents(packageJson);
+  }
+  /**
+   * This is a helper that takes care of updating the property with the file contents, and
+   * if the deferred promise exists, resolve it and delete it.
+   *
+   * @param contents  The contents of the package.json file.
+   */
+  protected updateContents(contents: string): IPackageJson {
+    this.contents = JSON.parse(contents) as IPackageJson;
+    if (this.defer) {
+      this.defer.resolve(this.contents);
+      this.defer = undefined;
+    }
+    return this.contents;
+  }
+}
+/**
+ * Shorthand for `new PackageInfo()`.
+ *
+ * @param args  The same parameters as the {@link PackageInfo} constructor.
+ * @returns A new instance of {@link PackageInfo}.
+ */
+export const packageInfo = (
+  ...args: ConstructorParameters<typeof PackageInfo>
+): PackageInfo => new PackageInfo(...args);
+/**
+ * The options for the {@link PackageInfo} Jimple's provider creator.
+ */
+export type PackageInfoProviderOptions = {
+  /**
+   * The name that will be used to register the service.
+   *
+   * @default 'packageInfo'
+   */
+  serviceName?: string;
+  /**
+   * A dictionary with the name of the services to inject. If one or more are not
+   * provided, the service will create new instances.
+   */
+  services?: {
+    [key in keyof PackageInfoInjectOptions]?: string;
+  };
+};
+/**
+ * A provider creator to register {@link PackageInfo} in a Jimple container.
+ */
+export const packageInfoProvider = providerCreator(
+  ({ serviceName = 'packageInfo', ...rest }: PackageInfoProviderOptions = {}) =>
+    (container) => {
+      container.set(serviceName, () => {
+        const { services = {} } = rest;
+        const inject = INJECT_NAMES.reduce<Partial<PackageInfoInjectOptions>>(
+          (acc, key) => {
+            const injectName = key as keyof PackageInfoInjectOptions;
+            if (services[injectName]) {
+              acc[injectName] = container.get<
+                PackageInfoInjectOptions[typeof injectName]
+              >(services[injectName]);
+            } else if (container.has(injectName)) {
+              acc[injectName] =
+                container.get<PackageInfoInjectOptions[typeof injectName]>(injectName);
+            }
+
+            return acc;
+          },
+          {},
+        );
+
+        return new PackageInfo({ inject });
+      });
+    },
+);

--- a/packages/public/package-info/tests/.eslintrc.js
+++ b/packages/public/package-info/tests/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: 'tsconfig.json',
+    sourceType: 'module',
+  },
+  plugins: ['@homer0'],
+  extends: [
+    'plugin:@homer0/node-typescript-with-prettier',
+    'plugin:@homer0/jest-with-prettier',
+  ],
+  ignorePatterns: ['.eslintrc.js'],
+  globals: {
+    fetch: true,
+  },
+  rules: {
+    'import/no-extraneous-dependencies': 'off',
+    'node/no-extraneous-import': 'off',
+  },
+};

--- a/packages/public/package-info/tests/index.test.ts
+++ b/packages/public/package-info/tests/index.test.ts
@@ -1,0 +1,223 @@
+/* eslint-disable max-classes-per-file */
+jest.mock('fs');
+jest.mock('fs/promises');
+jest.unmock('../src');
+
+import { Jimple } from '@homer0/jimple';
+import * as originalFsSync from 'fs';
+import * as originalFsPromises from 'fs/promises';
+import { PathUtils } from '@homer0/path-utils';
+import { PackageInfo, packageInfo, packageInfoProvider } from '../src';
+
+const mockFsSync = originalFsSync as jest.Mocked<typeof originalFsSync>;
+const mockFsPromises = originalFsPromises as jest.Mocked<typeof originalFsPromises>;
+
+describe('PathUtils', () => {
+  describe('class', () => {
+    beforeEach(() => {
+      mockFsSync.readFileSync.mockReset();
+      mockFsPromises.readFile.mockReset();
+    });
+
+    it('should be instantiated', () => {
+      // Given/When
+      const sut = new PackageInfo();
+      // Then
+      expect(sut).toBeInstanceOf(PackageInfo);
+    });
+
+    it('should get the contents of the package.json', async () => {
+      // Given
+      const pkgJson = {
+        name: '@homer0/test-package',
+        dependencies: {
+          '@homer0/jimple': '^1.0.0',
+        },
+      };
+      mockFsPromises.readFile.mockResolvedValueOnce(JSON.stringify(pkgJson));
+      // When
+      const sut = new PackageInfo();
+      const result = await sut.get();
+      // Then
+      expect(result).toEqual(pkgJson);
+      expect(mockFsPromises.readFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use a custom version of PathUtils', async () => {
+      // Given
+      const pkgJson = {
+        name: '@homer0/test-package',
+        dependencies: {
+          '@homer0/jimple': '^1.0.0',
+        },
+      };
+      mockFsPromises.readFile.mockResolvedValue(JSON.stringify(pkgJson));
+      const joinFn = jest.fn();
+      class MyPathUtils extends PathUtils {
+        override join(
+          ...args: Parameters<PathUtils['join']>
+        ): ReturnType<PathUtils['join']> {
+          joinFn(...args);
+          return super.join(...args);
+        }
+      }
+      const myPathUtils = new MyPathUtils();
+      // When
+      const sut = new PackageInfo({
+        inject: {
+          pathUtils: myPathUtils,
+        },
+      });
+      const result = await sut.get();
+      // Then
+      expect(result).toEqual(pkgJson);
+      expect(joinFn).toHaveBeenCalledTimes(1);
+      expect(joinFn).toHaveBeenCalledWith('package.json');
+    });
+
+    it('should only read the file once', async () => {
+      // Given
+      const pkgJson = {
+        name: '@homer0/test-package',
+        dependencies: {
+          '@homer0/jimple': '^1.0.0',
+        },
+      };
+      mockFsPromises.readFile.mockResolvedValue(JSON.stringify(pkgJson));
+      // When
+      const sut = new PackageInfo();
+      const [result1, result2] = await Promise.all([sut.get(), sut.get()]);
+      const result3 = await sut.get();
+      // Then
+      expect(result1).toEqual(pkgJson);
+      expect(result2).toEqual(pkgJson);
+      expect(result3).toEqual(pkgJson);
+      expect(mockFsPromises.readFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('should synchronously get the contents of the package.json', () => {
+      // Given
+      const pkgJson = {
+        name: '@homer0/test-package',
+        dependencies: {
+          '@homer0/jimple': '^1.0.0',
+        },
+      };
+      mockFsSync.readFileSync.mockReturnValueOnce(JSON.stringify(pkgJson));
+      // When
+      const sut = new PackageInfo();
+      const result1 = sut.getSync();
+      const result2 = sut.getSync();
+      // Then
+      expect(result1).toEqual(pkgJson);
+      expect(result2).toEqual(pkgJson);
+      expect(mockFsSync.readFileSync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('shorthand', () => {
+    it('should have a shorthand function', () => {
+      // Given/When/Then
+      expect(packageInfo()).toBeInstanceOf(PackageInfo);
+    });
+  });
+
+  describe('provider', () => {
+    it('should include a Jimple provider', () => {
+      // Given
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const container = new Container();
+      // When
+      packageInfoProvider.register(container);
+      const [[serviceName, serviceFn]] = setFn.mock.calls as [
+        [string, () => PackageInfo],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(serviceName).toBe('packageInfo');
+      expect(sut).toBeInstanceOf(PackageInfo);
+    });
+
+    it('should allow custom options on its provider', () => {
+      // Given
+      const getFn = jest.fn();
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override get<T>(key: string): T {
+          getFn(key);
+          return super.get<T>(key);
+        }
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const container = new Container({
+        pathUtils: new PathUtils(),
+      });
+      const providerServiceName = 'myPackageInfo';
+      // When
+      packageInfoProvider({
+        serviceName: providerServiceName,
+      }).register(container);
+      const [, [serviceName, serviceFn]] = setFn.mock.calls as [
+        [string, () => PathUtils],
+        [string, () => PackageInfo],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(serviceName).toBe(providerServiceName);
+      expect(sut).toBeInstanceOf(PackageInfo);
+    });
+
+    it('should allow custom services on its provider', () => {
+      // Given
+      const getFn = jest.fn();
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override get<T>(key: string): T {
+          getFn(key);
+          return super.get<T>(key);
+        }
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const joinFn = jest.fn();
+      class MyPathUtils extends PathUtils {
+        override join(
+          ...args: Parameters<PathUtils['join']>
+        ): ReturnType<PathUtils['join']> {
+          joinFn(...args);
+          return super.join(...args);
+        }
+      }
+      const container = new Container({
+        myPathUtils: new MyPathUtils(),
+      });
+      const providerServiceName = 'myPackageInfo';
+      // When
+      packageInfoProvider({
+        serviceName: providerServiceName,
+        services: {
+          pathUtils: 'myPathUtils',
+        },
+      }).register(container);
+      const [, [serviceName, serviceFn]] = setFn.mock.calls as [
+        [string, () => PathUtils],
+        [string, () => PackageInfo],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(serviceName).toBe(providerServiceName);
+      expect(sut).toBeInstanceOf(PackageInfo);
+    });
+  });
+});

--- a/packages/public/package-info/tests/tsconfig.json
+++ b/packages/public/package-info/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@homer0/tsconfig/tsconfig.node.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "strict": true,
+    "noImplicitAny": true
+  },
+  "include": ["./"]
+}

--- a/packages/public/package-info/tsconfig.json
+++ b/packages/public/package-info/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@homer0/tsconfig/tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "emitDecoratorMetadata": false,
+    "incremental": false
+  },
+  "include": ["src/**/*.ts", "tsup.config.ts"]
+}

--- a/packages/public/package-info/tsup.config.ts
+++ b/packages/public/package-info/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  sourcemap: true,
+  clean: true,
+  format: ['esm', 'cjs'],
+  legacyOutput: true,
+  dts: true,
+});

--- a/utils/scripts/build
+++ b/utils/scripts/build
@@ -10,6 +10,6 @@ buildPkg deferred;
 buildPkg api-utils;
 buildPkg events-hub;
 buildPkg extend-promise;
-buildPkg package-info;
 buildPkg path-utils;
+buildPkg package-info;
 buildPkg env-utils;

--- a/utils/scripts/build
+++ b/utils/scripts/build
@@ -1,2 +1,15 @@
 #!/bin/bash -e
-lerna run build $@
+buildPkg() {
+  lerna run build --scope @homer0/${1} --stream
+}
+
+buildPkg jimple;
+buildPkg deep-assign;
+buildPkg object-utils;
+buildPkg deferred;
+buildPkg api-utils;
+buildPkg events-hub;
+buildPkg extend-promise;
+buildPkg package-info;
+buildPkg path-utils;
+buildPkg env-utils;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6672,6 +6672,11 @@ p-waterfall@^2.1.1:
   dependencies:
     p-reduce "^2.0.0"
 
+package-json-type@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/package-json-type/-/package-json-type-1.0.3.tgz#f869b8abb094ae0e5bdd7a01355eeddcdf3fb597"
+  integrity sha512-Bey4gdRuOwDbS8Fj1qA3/pTq5r8pqiI5E3tjSqCdhaLSsyGG364VFzXLTIexN5AaNGe/vgdBzLfoKdr7EVg2KQ==
+
 pacote@^11.2.6:
   version "11.3.5"
   resolved "https://registry.yarnpkg.com/pacote/-/pacote-11.3.5.tgz#73cf1fc3772b533f575e39efa96c50be8c3dc9d2"


### PR DESCRIPTION
### What does this PR do?

It migrates the `packageInfo` module from `wootils` into its own package.

I also took the opportunity to move it to TypeScript.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```