### PR TITLE
New package: simple-logger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,15 @@ jobs:
           flag-name: public-root-file
           path-to-lcov: ./packages/public/root-file/coverage/lcov.info
           base-path: ./packages/public/root-file
+      - name: Coveralls for public/simple-logger
+        if: ${{ matrix.node == '14' }}
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
+          flag-name: public-simple-logger
+          path-to-lcov: ./packages/public/simple-logger/coverage/lcov.info
+          base-path: ./packages/public/simple-logger
 
   finish:
       needs: build

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/../utils/scripts/require-yarn"
 
-yarn test
+yarn types:check && yarn test

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "build": "./utils/scripts/build",
     "test": "./utils/scripts/test",
+    "types:check": "./utils/scripts/types-check",
     "lint": "./utils/scripts/lint",
     "lint:all": "./utils/scripts/lint-all",
     "todo": "./utils/scripts/todo",

--- a/packages/public/api-utils/package.json
+++ b/packages/public/api-utils/package.json
@@ -41,6 +41,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/deep-assign/package.json
+++ b/packages/public/deep-assign/package.json
@@ -38,6 +38,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/deferred/package.json
+++ b/packages/public/deferred/package.json
@@ -38,6 +38,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/env-utils/README.md
+++ b/packages/public/env-utils/README.md
@@ -83,7 +83,7 @@ const env = container.get('envUtils');
 And since the provider is a "provider creator" (created with [my custom version of Jimple](https:///npmjs.com/package/@homer0/jimple)), you can customize its service name:
 
 ```ts
-constainer.register(
+container.register(
   envUtilsProvider({
     serviceName: 'myEnvUtils',
   }),

--- a/packages/public/env-utils/package.json
+++ b/packages/public/env-utils/package.json
@@ -41,6 +41,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/env-utils/package.json
+++ b/packages/public/env-utils/package.json
@@ -22,6 +22,9 @@
   "files": [
     "dist/"
   ],
+  "dependencies": {
+    "@homer0/jimple": "^0.0.0-development"
+  },
   "devDependencies": {
     "@types/jest": "^28.1.1",
     "jest": "^28.1.1",

--- a/packages/public/env-utils/tsup.config.ts
+++ b/packages/public/env-utils/tsup.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   legacyOutput: true,
   dts: true,
+  bundle: false,
 });

--- a/packages/public/events-hub/package.json
+++ b/packages/public/events-hub/package.json
@@ -38,6 +38,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/extend-promise/package.json
+++ b/packages/public/extend-promise/package.json
@@ -38,6 +38,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/jimple/package.json
+++ b/packages/public/jimple/package.json
@@ -41,6 +41,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/object-utils/package.json
+++ b/packages/public/object-utils/package.json
@@ -42,6 +42,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/package-info/README.md
+++ b/packages/public/package-info/README.md
@@ -21,6 +21,50 @@ const info = await pkg.get();
 const info = pkg.getSync();
 ```
 
+#### Jimple provider
+
+If your app uses a [Jimple container](https://npmjs.com/package/jimple), you can register `PackageInfo` as the `packageInfo` service by using its provider:
+
+```ts
+import { packageInfoProvider } from '@homer0/package-info';
+
+// ...
+
+container.register(packageInfoProvider);
+
+// ...
+
+const info = container.get('packageInfo');
+```
+
+And since the provider is a "provider creator" (created with [my custom version of Jimple](https:///npmjs.com/package/@homer0/jimple)), you can customize its service name:
+
+```ts
+container.register(
+  packageInfoProvider({
+    serviceName: 'myPackageInfo',
+  }),
+);
+```
+
+##### Dependencies
+
+`PackageInfo` depends on the following services, and when used with Jimple, it will try to find them in the container, otherwise, it will create new instances:
+
+- [`@homer0/path-utils`](https://npmjs.com/package/@homer0/path-utils), with the name `pathUtils`. Used to generate the paths relative to the project root.
+
+If you already implement the dependencies, but with a different name, you can specify them in the provider:
+
+```ts
+container.register(
+  packageInfoProvider({
+    services: {
+      pathUtils: 'myPathUtils',
+    },
+  }),
+);
+```
+
 ### 🤘 Development
 
 As this project is part of the `packages` monorepo, it requires Yarn, and some of the tooling, like ESLint and Husky, are installed on the root's `package.json`.

--- a/packages/public/package-info/package.json
+++ b/packages/public/package-info/package.json
@@ -22,6 +22,10 @@
   "files": [
     "dist/"
   ],
+  "dependencies": {
+    "@homer0/jimple": "^0.0.0-development",
+    "@homer0/path-utils": "^0.0.0-development"
+  },
   "devDependencies": {
     "@types/jest": "^28.1.1",
     "jest": "^28.1.1",

--- a/packages/public/package-info/package.json
+++ b/packages/public/package-info/package.json
@@ -43,6 +43,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/package-info/tsup.config.ts
+++ b/packages/public/package-info/tsup.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   legacyOutput: true,
   dts: true,
+  bundle: false,
 });

--- a/packages/public/path-utils/README.md
+++ b/packages/public/path-utils/README.md
@@ -89,7 +89,7 @@ const paths = container.get('pathUtils');
 And since the provider is a "provider creator" (created with [my custom version of Jimple](https:///npmjs.com/package/@homer0/jimple)), you can customize its service name, and even the constructor options:
 
 ```ts
-constainer.register(
+container.register(
   pathUtilsProvider({
     serviceName: 'myPathUtils',
     home: '/some-other-root-folder',

--- a/packages/public/path-utils/package.json
+++ b/packages/public/path-utils/package.json
@@ -41,6 +41,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/path-utils/package.json
+++ b/packages/public/path-utils/package.json
@@ -22,6 +22,9 @@
   "files": [
     "dist/"
   ],
+  "dependencies": {
+    "@homer0/jimple": "^0.0.0-development"
+  },
   "devDependencies": {
     "@types/jest": "^28.1.1",
     "jest": "^28.1.1",

--- a/packages/public/path-utils/tsup.config.ts
+++ b/packages/public/path-utils/tsup.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   legacyOutput: true,
   dts: true,
+  bundle: false,
 });

--- a/packages/public/root-file/.eslintrc.js
+++ b/packages/public/root-file/.eslintrc.js
@@ -15,11 +15,5 @@ module.exports = {
         allowModules: ['@homer0/jimple', '@homer0/path-utils'],
       },
     ],
-    'node/no-missing-import': [
-      'error',
-      {
-        allowModules: ['package-json-type'],
-      },
-    ],
   },
 };

--- a/packages/public/root-file/README.md
+++ b/packages/public/root-file/README.md
@@ -21,6 +21,50 @@ const info = await root.import('some-file.js');
 const info = root.require('some-file.js');
 ```
 
+#### Jimple provider
+
+If your app uses a [Jimple container](https://npmjs.com/package/jimple), you can register `RootFile` as the `rootFile` service by using its provider:
+
+```ts
+import { rootFileProvider } from '@homer0/root-file';
+
+// ...
+
+container.register(rootFileProvider);
+
+// ...
+
+const env = container.get('rootFile');
+```
+
+And since the provider is a "provider creator" (created with [my custom version of Jimple](https:///npmjs.com/package/@homer0/jimple)), you can customize its service name:
+
+```ts
+container.register(
+  rootFileProvider({
+    serviceName: 'myRootFile',
+  }),
+);
+```
+
+##### Dependencies
+
+`RootFile` depends on the following services, and when used with Jimple, it will try to find them in the container, otherwise, it will create new instances:
+
+- [`@homer0/path-utils`](https://npmjs.com/package/@homer0/path-utils), with the name `pathUtils`. Used to generate the paths relative to the project root.
+
+If you already implement the dependencies, but with a different name, you can specify them in the provider:
+
+```ts
+container.register(
+  rootFileProvider({
+    services: {
+      pathUtils: 'myPathUtils',
+    },
+  }),
+);
+```
+
 ### 🤘 Development
 
 As this project is part of the `packages` monorepo, it requires Yarn, and some of the tooling, like ESLint and Husky, are installed on the root's `package.json`.

--- a/packages/public/root-file/package.json
+++ b/packages/public/root-file/package.json
@@ -22,6 +22,10 @@
   "files": [
     "dist/"
   ],
+  "dependencies": {
+    "@homer0/jimple": "^0.0.0-development",
+    "@homer0/path-utils": "^0.0.0-development"
+  },
   "devDependencies": {
     "@types/jest": "^28.1.1",
     "jest": "^28.1.1",

--- a/packages/public/root-file/package.json
+++ b/packages/public/root-file/package.json
@@ -42,6 +42,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/root-file/tsup.config.ts
+++ b/packages/public/root-file/tsup.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   legacyOutput: true,
   dts: true,
+  bundle: false,
 });

--- a/packages/public/simple-logger/.eslintrc.js
+++ b/packages/public/simple-logger/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: 'tsconfig.json',
+    sourceType: 'module',
+  },
+  plugins: ['@homer0'],
+  extends: ['plugin:@homer0/node-typescript-with-prettier'],
+  ignorePatterns: ['.eslintrc.js', 'dist/'],
+  rules: {
+    'node/no-extraneous-import': [
+      'error',
+      {
+        allowModules: ['@homer0/jimple', '@homer0/package-info'],
+      },
+    ],
+  },
+};

--- a/packages/public/simple-logger/.eslintrc.js
+++ b/packages/public/simple-logger/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     'node/no-extraneous-import': [
       'error',
       {
-        allowModules: ['@homer0/jimple', '@homer0/package-info'],
+        allowModules: ['@homer0/jimple', '@homer0/path-utils', '@homer0/package-info'],
       },
     ],
   },

--- a/packages/public/simple-logger/.jestrc.js
+++ b/packages/public/simple-logger/.jestrc.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+/**
+ * @type {import('ts-jest').InitialOptionsTsJest}
+ */
+module.exports = {
+  preset: 'ts-jest',
+  automock: true,
+  collectCoverage: true,
+  testPathIgnorePatterns: ['/node_modules/'],
+  unmockedModulePathPatterns: [
+    '/node_modules/',
+    'jimple',
+    'path-utils',
+    'package-info',
+    'mocks',
+  ],
+  coveragePathIgnorePatterns: ['/node_modules/', '/mocks/'],
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: path.join(__dirname, 'tests', 'tsconfig.json'),
+    },
+  },
+};

--- a/packages/public/simple-logger/.jestrc.js
+++ b/packages/public/simple-logger/.jestrc.js
@@ -8,13 +8,7 @@ module.exports = {
   automock: true,
   collectCoverage: true,
   testPathIgnorePatterns: ['/node_modules/'],
-  unmockedModulePathPatterns: [
-    '/node_modules/',
-    'jimple',
-    'path-utils',
-    'package-info',
-    'mocks',
-  ],
+  unmockedModulePathPatterns: ['/node_modules/', 'jimple', 'path-utils', 'mocks'],
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/'],
   testEnvironment: 'node',
   globals: {

--- a/packages/public/simple-logger/README.md
+++ b/packages/public/simple-logger/README.md
@@ -146,7 +146,7 @@ logger.log('Starting the app');
 // your package.json
 ```
 
-You can also specify a `nameForCLI` on your `package.json`, and it will use that instead of the `name`.
+You can also specify a `appLoggerPrefix` on your `package.json`, and it will use that instead of the `name`.
 
 ### 🤘 Development
 

--- a/packages/public/simple-logger/README.md
+++ b/packages/public/simple-logger/README.md
@@ -1,0 +1,160 @@
+# 💬 Simple logger
+
+A small service to log messages in the console.
+
+## 🍿 Usage
+
+- ⚙️ [Examples](#%EF%B8%8F-examples)
+- 🤘 [Development](#-development)
+
+### ⚙️ Example
+
+#### Logging messages
+
+```ts
+import { simpleLogger } from '@homer0/simple-logger';
+
+const logger = simpleLogger();
+
+logger.log('Starting the app');
+// Will log the message the same way `console.log` would.
+
+if (usingExperimentalFeature()) {
+  logger.warn('WARNING: This feature is experimental');
+  // Will log a yellow message.
+}
+
+if (onDevelopment()) {
+  logger.info('Running on a development environment');
+  // Will log a gray message.
+}
+
+if (loadConfiguration()) {
+  logger.success('The configuration was successfully loaded');
+  // Will log a green message
+}
+
+try {
+  methodThatMayThrowAnError();
+} catch (error) {
+  logger.error('Damn it!', error);
+  // Will log `Damn it!` on red, and the `error` stack trace information on `gray`.
+}
+```
+
+#### Colored messages
+
+This was demonstrated on the example above:
+
+1. `success(message)` will log a green message.
+2. `warn(message)` will log a yellow message.
+3. `error(message)` will log a red message.
+4. `info(message)` will log a gray message.
+
+But they all depend on this method: `log(message, color)`; it allows you to specify one of the colors available on the [`colors`](https://npmjs.com/package/colors) package.
+
+By default, it uses the console default text color, but you can specify a different color for the message.
+
+```ts
+logger.log('Starting the app', 'green');
+```
+
+#### Multiple messages at once
+
+All the methods support both a single message or an `Array` of them:
+
+```ts
+logger.info(['App running', 'connection detected', 'starting Skynet...']);
+// This will log three gray messages.
+```
+
+You can even specify a color for each message:
+
+```ts
+logger.success([
+  'It works!',
+  ['wait, something is happening', 'gray'],
+  'Nevermind, Skynet is up and running!',
+]);
+// This will log the first and third message on green and the second one on gray.
+```
+
+#### Prefixing the messages
+
+When creating the logger, you can specify a `prefix` option that will be prepended to each message.
+
+```ts
+const logger = simpleLogger({ prefix: 'my-app' });
+logger.log('Starting the app');
+// Will log `[my-app] Starting the app`
+```
+
+#### Date and time
+
+The same way you can specify the prefix when creating the logger, you also have a `showTime` option that will make the logger show the current date and time on each message.
+
+```ts
+const logger = simpleLogger({ showTime: true });
+logger.log('Starting the app');
+// Will log something like `[2022-06-25 19:41:11] Starting the app`
+```
+
+> Yes, you can use both `prefix` and `showTime` together.
+
+#### Jimple provider
+
+If your app uses a [Jimple container](https://npmjs.com/package/jimple), you can register `SimpleLogger` as the `simpleLogger` service by using its provider:
+
+```ts
+import { simpleLoggerProvider } from '@homer0/simple-logger';
+
+// ...
+
+container.register(simpleLoggerProvider);
+
+// ...
+
+const logger = container.get('simpleLogger');
+```
+
+And since the provider is a "provider creator" (created with [my custom version of Jimple](https:///npmjs.com/package/@homer0/jimple)), you can customize its service name:
+
+```ts
+constainer.register(
+  simpleLoggerProvider({
+    serviceName: 'myLogger',
+  }),
+);
+```
+
+#### App logger provider
+
+The package has an alternative service provider for Jimple that gets the project name from the `package.json` and uses as the prefix:
+
+```ts
+import { appLoggerProvider } from '@homer0/simple-logger';
+
+// ...
+
+container.register(appLoggerProvider);
+
+// ...
+
+const logger = container.get('appLogger');
+logger.log('Starting the app');
+// Will log `[my-app] Starting the app`, where `my-app` is the `name` in
+// your package.json
+```
+
+You can also specify a `nameForCLI` on your `package.json`, and it will use that instead of the `name`.
+
+### 🤘 Development
+
+As this project is part of the `packages` monorepo, it requires Yarn, and some of the tooling, like ESLint and Husky, are installed on the root's `package.json`.
+
+#### Yarn tasks
+
+| Task    | Description          |
+| ------- | -------------------- |
+| `test`  | Runs the unit tests. |
+| `build` | Bundles the project. |

--- a/packages/public/simple-logger/README.md
+++ b/packages/public/simple-logger/README.md
@@ -120,7 +120,7 @@ const logger = container.get('simpleLogger');
 And since the provider is a "provider creator" (created with [my custom version of Jimple](https:///npmjs.com/package/@homer0/jimple)), you can customize its service name:
 
 ```ts
-constainer.register(
+container.register(
   simpleLoggerProvider({
     serviceName: 'myLogger',
   }),
@@ -147,6 +147,26 @@ logger.log('Starting the app');
 ```
 
 You can also specify a `appLoggerPrefix` on your `package.json`, and it will use that instead of the `name`.
+
+##### Dependencies
+
+The "app logger provider" depends on the following services, and it will try to find them in the container, otherwise, it will create new instances:
+
+- [`@homer0/package-info`](https://npmjs.com/package/@homer0/package-info), with the name `package-info`. Used to get the project's `package.json` information.
+- [`@homer0/path-utils`](https://npmjs.com/package/@homer0/path-utils), with the name `pathUtils`. Needed by `package-info` to generate the paths relative to the project root.
+
+If you already implement the dependencies, but with a different name, you can specify them in the provider:
+
+```ts
+container.register(
+  appLoggerProvider({
+    services: {
+      packageInfo: 'myPackageInfo',
+      pathUtils: 'myPathUtils',
+    },
+  }),
+);
+```
 
 ### 🤘 Development
 

--- a/packages/public/simple-logger/package.json
+++ b/packages/public/simple-logger/package.json
@@ -22,9 +22,14 @@
   "files": [
     "dist/"
   ],
+  "dependencies": {
+    "colors": "^1.4.0",
+    "@homer0/jimple": "^0.0.0-development",
+    "@homer0/package-info": "^0.0.0-development",
+    "@homer0/path-utils": "^0.0.0-development"
+  },
   "devDependencies": {
     "@types/jest": "^28.1.1",
-    "colors": "^1.4.0",
     "jest": "^28.1.1",
     "ts-jest": "^28.0.4",
     "tsup": "^6.1.2",

--- a/packages/public/simple-logger/package.json
+++ b/packages/public/simple-logger/package.json
@@ -44,6 +44,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
     "build": "tsup src/index.ts",
     "prepublishOnly": "npm run build"
   }

--- a/packages/public/simple-logger/package.json
+++ b/packages/public/simple-logger/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@homer0/simple-logger",
+  "description": "A small service to log messages in the console",
+  "version": "0.0.0-development",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/homer0/packages.git",
+    "directory": "packages/public/simple-logger"
+  },
+  "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
+  "license": "MIT",
+  "keywords": [
+    "logger",
+    "console",
+    "utility",
+    "wootils",
+    "javascript"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist/"
+  ],
+  "devDependencies": {
+    "@types/jest": "^28.1.1",
+    "colors": "^1.4.0",
+    "jest": "^28.1.1",
+    "ts-jest": "^28.0.4",
+    "tsup": "^6.1.2",
+    "typescript": "^4.7.3"
+  },
+  "engine-strict": true,
+  "engines": {
+    "node": ">=14"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "test": "jest -c ./.jestrc.js",
+    "build": "tsup src/index.ts",
+    "prepublishOnly": "npm run build"
+  }
+}

--- a/packages/public/simple-logger/src/index.ts
+++ b/packages/public/simple-logger/src/index.ts
@@ -2,37 +2,86 @@ import colors from 'colors/safe';
 import { pathUtils, type PathUtils } from '@homer0/path-utils';
 import { packageInfo, type PackageInfo } from '@homer0/package-info';
 import { providerCreator, injectHelper } from '@homer0/jimple';
-
+/**
+ * The colors supported by the service.
+ */
 export type SimpleLoggerColor =
   | Exclude<keyof typeof colors, 'enabled' | 'enable' | 'disable' | 'setTheme'>
   | 'raw';
-
+/**
+ * It can be a simple text message, or a message and a color.
+ */
 export type SimpleLoggerLine = string | [string, SimpleLoggerColor];
+/**
+ * This is the type used on all the log methods: it can be a string, a list of strings, or
+ * a list of messages and colors.
+ */
 export type SimpleLoggerMessage = string | SimpleLoggerLine[];
-
+/**
+ * The options for the service constructor.
+ */
 export type SimpleLoggerOptions = {
+  /**
+   * A prefix to include in front of all the messages.
+   */
   prefix?: string;
+  /**
+   * Whether or not to show the time on each message.
+   */
   showTime?: boolean;
 };
 
 type ExceptionLike = {
   stack: string;
 };
-
+/**
+ * Utility service to log messages on the console.
+ */
 export class SimpleLogger {
+  /**
+   * A prefix to include in front of all the messages.
+   */
   readonly prefix: string;
+  /**
+   * Whether or not to show the time on each message.
+   */
   readonly showTime: boolean;
   constructor({ prefix = '', showTime = false }: SimpleLoggerOptions = {}) {
     this.prefix = prefix;
     this.showTime = showTime;
-
     this.log = this.log.bind(this);
     this.success = this.success.bind(this);
     this.info = this.info.bind(this);
     this.warn = this.warn.bind(this);
     this.error = this.error.bind(this);
   }
-
+  /**
+   * Logs a message with an specific color on the console.
+   *
+   * @param message  A text message to log or a list of them.
+   * @param color    The color of the message (the default is the terminal default).
+   *                 This can be overwritten line by line when the message is an array,
+   *                 take a look at the example.
+   * @example
+   *
+   *   // Simple
+   *   logger.log('hello world');
+   *   // Custom color
+   *   logger.log('It was the shadow who did it', 'red');
+   *   // A list of messages all the same color
+   *   logger.log(["Ph'nglu", "mglw'nafh"], 'grey');
+   *   // A list of messages with different colors per line
+   *   logger.log(
+   *     [
+   *       "Ph'nglu",
+   *       "mglw'nafh",
+   *       ['Cthulhu', 'green'],
+   *       ["R'lyeh wgah'nagl fhtagn", 'red'],
+   *     ],
+   *     'grey',
+   *   );
+   *
+   */
   log(message: SimpleLoggerMessage, color: SimpleLoggerColor = 'raw'): void {
     const lines: string[] = [];
     if (Array.isArray(message)) {
@@ -50,19 +99,48 @@ export class SimpleLogger {
     // eslint-disable-next-line no-console
     lines.forEach((line) => console.log(line));
   }
-
+  /**
+   * Logs a success (green) message or messages on the console.
+   *
+   * @param message  A single message of a list of them.
+   * @see {@link SimpleLogger.log}
+   */
   success(message: SimpleLoggerMessage): void {
     this.log(message, 'green');
   }
-
+  /**
+   * Logs an information (gray) message or messages on the console.
+   *
+   * @param message  A single message of a list of them.
+   * @see {@link SimpleLogger.log}
+   */
   info(message: SimpleLoggerMessage): void {
     this.log(message, 'grey');
   }
-
+  /**
+   * Logs a warning (yellow) message or messages on the console.
+   *
+   * @param message  A single message of a list of them.
+   * @see {@link SimpleLogger.log}
+   */
   warn(message: SimpleLoggerMessage): void {
     this.log(message, 'yellow');
   }
-
+  /**
+   * Logs an error (red) message or messages on the console.
+   *
+   * @param message    A single message of a list of them.
+   *                   See the `log()` documentation to see all the supported
+   *                   properties for the `message` parameter. Different from the other
+   *                   log methods, you can use an `Error` object and the method will
+   *                   take care of extracting the message and the stack information.
+   * @param exception  If the exception has a `stack`
+   *                   property, the method will log each of the stack calls using
+   *                   `info()`.
+   * @template ErrorType  The type of the exception, to be infered and validate if it
+   *                      has a `stack` property.
+   * @see {@link SimpleLogger.log}
+   */
   error<ErrorType extends Error, ExceptionType extends ExceptionLike | Error | string>(
     message: SimpleLoggerMessage | ErrorType,
     exception?: ExceptionType,
@@ -82,7 +160,12 @@ export class SimpleLogger {
       }
     }
   }
-
+  /**
+   * Prefixes a message with the text sent to the constructor and, if enabled, the current
+   * time.
+   *
+   * @param text  The text that needs the prefix.
+   */
   protected addPrefix(text: string): string {
     const parts: string[] = [];
     // If a prefix was set on the constructor...
@@ -102,7 +185,14 @@ export class SimpleLogger {
     // Join the list into a single text message.
     return parts.join(' ').trim();
   }
-
+  /**
+   * Gets a function to modify the color of a string. The reason for this _"proxy method"_
+   * is that the `colors` module doesn't have a `raw` option and the alternative would've
+   * been adding a few `if`s on the `log` method.
+   *
+   * @param color  The name of the color.
+   * @returns A function that receives a string and returns it colored.
+   */
   protected getColorFn(color: SimpleLoggerColor): (str: string) => string {
     if (color === 'raw') {
       return (str: string) => str;
@@ -119,7 +209,9 @@ export class SimpleLogger {
 export const simpleLogger = (
   ...args: ConstructorParameters<typeof SimpleLogger>
 ): SimpleLogger => new SimpleLogger(...args);
-
+/**
+ * The options for the {@link SimpleLogger} Jimple's provider creator.
+ */
 export type SimpleLoggerProviderOptions = SimpleLoggerOptions & {
   /**
    * The name that will be used to register the service.
@@ -128,19 +220,32 @@ export type SimpleLoggerProviderOptions = SimpleLoggerOptions & {
    */
   serviceName?: string;
 };
-
+/**
+ * A provider creator to register {@link SimpleLogger} in a Jimple container.
+ */
 export const simpleLoggerProvider = providerCreator(
   ({ serviceName = 'simpleLogger', ...rest }: SimpleLoggerProviderOptions = {}) =>
     (container) => {
       container.set(serviceName, () => new SimpleLogger(rest));
     },
 );
-
+/**
+ * The dictionary of dependencies that can be injected in the "app logger provider".
+ */
 type AppLoggerProviderInjectOptions = {
+  /**
+   * The service that gets the information from the `package.json`.
+   */
   packageInfo: PackageInfo;
+  /**
+   * The service that creates paths relative to the project root, needed to get the
+   * `package.json`.
+   */
   pathUtils: PathUtils;
 };
-
+/**
+ * The options for the "app logger" Jimple's provider creator.
+ */
 export type AppLoggerProviderOptions = Omit<SimpleLoggerProviderOptions, 'prefix'> & {
   /**
    * A dictionary with the name of the services to inject. If one or more are not
@@ -150,7 +255,10 @@ export type AppLoggerProviderOptions = Omit<SimpleLoggerProviderOptions, 'prefix
     [key in keyof AppLoggerProviderInjectOptions]?: string;
   };
 };
-
+/**
+ * An alaternative to the basic {@link SimpleLogger} provider creator, that gets the
+ * project name from the `package.json` and sets it as the prefix for the messages.
+ */
 export const appLoggerProvider = providerCreator(
   ({
       serviceName = 'appLogger',

--- a/packages/public/simple-logger/src/index.ts
+++ b/packages/public/simple-logger/src/index.ts
@@ -1,0 +1,176 @@
+import colors from 'colors/safe';
+import { pathUtils, type PathUtils } from '@homer0/path-utils';
+import { packageInfo, type PackageInfo } from '@homer0/package-info';
+import { providerCreator, injectHelper } from '@homer0/jimple';
+
+export type SimpleLoggerColor =
+  | Exclude<keyof typeof colors, 'enabled' | 'enable' | 'disable' | 'setTheme'>
+  | 'raw';
+
+export type SimpleLoggerLine = string | [string, SimpleLoggerColor];
+export type SimpleLoggerMessage = string | SimpleLoggerLine[];
+
+export type SimpleLoggerOptions = {
+  prefix?: string;
+  showTime?: boolean;
+};
+
+type ExceptionLike = {
+  stack: string;
+};
+
+export class SimpleLogger {
+  readonly prefix: string;
+  readonly showTime: boolean;
+  constructor({ prefix = '', showTime = false }: SimpleLoggerOptions = {}) {
+    this.prefix = prefix;
+    this.showTime = showTime;
+
+    this.log = this.log.bind(this);
+    this.success = this.success.bind(this);
+    this.info = this.info.bind(this);
+    this.warn = this.warn.bind(this);
+    this.error = this.error.bind(this);
+  }
+
+  log(message: SimpleLoggerMessage, color: SimpleLoggerColor = 'raw'): void {
+    const lines: string[] = [];
+    if (Array.isArray(message)) {
+      message.forEach((line) => {
+        if (Array.isArray(line)) {
+          lines.push(this.getColorFn(line[1])(this.addPrefix(line[0])));
+        } else {
+          lines.push(this.getColorFn(color)(this.addPrefix(line)));
+        }
+      });
+    } else {
+      lines.push(this.getColorFn(color)(this.addPrefix(message)));
+    }
+
+    // eslint-disable-next-line no-console
+    lines.forEach((line) => console.log(line));
+  }
+
+  success(message: SimpleLoggerMessage): void {
+    this.log(message, 'green');
+  }
+
+  info(message: SimpleLoggerMessage): void {
+    this.log(message, 'grey');
+  }
+
+  warn(message: SimpleLoggerMessage): void {
+    this.log(message, 'yellow');
+  }
+
+  error<ErrorType extends Error, ExceptionType extends ExceptionLike | Error | string>(
+    message: SimpleLoggerMessage | ErrorType,
+    exception?: ExceptionType,
+  ): void {
+    if (message instanceof Error) {
+      this.error(message.message, message);
+      return;
+    }
+    this.log(message, 'red');
+    if (exception) {
+      if (typeof exception !== 'string' && exception.stack) {
+        const stack = exception.stack.split('\n').map((line) => line.trim());
+        stack.splice(0, 1);
+        this.info(stack);
+      } else {
+        this.log(String(exception));
+      }
+    }
+  }
+
+  protected addPrefix(text: string): string {
+    const parts: string[] = [];
+    // If a prefix was set on the constructor...
+    if (this.prefix) {
+      // ...add it as first element.
+      parts.push(`[${this.prefix}]`);
+    }
+    // If the `showTime` setting is enabled...
+    if (this.showTime) {
+      // ...add the current time to the list.
+      const time = new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '');
+
+      parts.push(`[${time}]`);
+    }
+    // Add the original text.
+    parts.push(text);
+    // Join the list into a single text message.
+    return parts.join(' ').trim();
+  }
+
+  protected getColorFn(color: SimpleLoggerColor): (str: string) => string {
+    if (color === 'raw') {
+      return (str: string) => str;
+    }
+    return colors[color];
+  }
+}
+/**
+ * Shorthand for `new SimpleLogger()`.
+ *
+ * @param args  The same parameters as the {@link SimpleLogger} constructor.
+ * @returns A new instance of {@link SimpleLogger}.
+ */
+export const simpleLogger = (
+  ...args: ConstructorParameters<typeof SimpleLogger>
+): SimpleLogger => new SimpleLogger(...args);
+
+export type SimpleLoggerProviderOptions = SimpleLoggerOptions & {
+  /**
+   * The name that will be used to register the service.
+   *
+   * @default 'simpleLogger'
+   */
+  serviceName?: string;
+};
+
+export const simpleLoggerProvider = providerCreator(
+  ({ serviceName = 'simpleLogger', ...rest }: SimpleLoggerProviderOptions = {}) =>
+    (container) => {
+      container.set(serviceName, () => new SimpleLogger(rest));
+    },
+);
+
+type AppLoggerProviderInjectOptions = {
+  packageInfo: PackageInfo;
+  pathUtils: PathUtils;
+};
+
+export type AppLoggerProviderOptions = Omit<SimpleLoggerProviderOptions, 'prefix'> & {
+  /**
+   * A dictionary with the name of the services to inject. If one or more are not
+   * provided, the service will create new instances.
+   */
+  services?: {
+    [key in keyof AppLoggerProviderInjectOptions]?: string;
+  };
+};
+
+export const appLoggerProvider = providerCreator(
+  ({
+      serviceName = 'appLogger',
+      services = {},
+      ...rest
+    }: AppLoggerProviderOptions = {}) =>
+    (container) => {
+      container.set(serviceName, () => {
+        const deps = injectHelper<AppLoggerProviderInjectOptions>();
+        const inject = deps.resolve(['packageInfo', 'pathUtils'], container, services);
+        const usePathUtils = deps.get(inject, 'pathUtils', () => pathUtils());
+        const usePkgInfo = deps.get(inject, 'packageInfo', () =>
+          packageInfo({
+            inject: { pathUtils: usePathUtils },
+          }),
+        );
+        const pkg = usePkgInfo.getSync();
+        // eslint-disable-next-line dot-notation
+        const prefix = pkg['nameForCLI'] || pkg.name!;
+        return new SimpleLogger({ prefix, ...rest });
+      });
+    },
+);

--- a/packages/public/simple-logger/src/index.ts
+++ b/packages/public/simple-logger/src/index.ts
@@ -277,7 +277,7 @@ export const appLoggerProvider = providerCreator(
         );
         const pkg = usePkgInfo.getSync();
         // eslint-disable-next-line dot-notation
-        const prefix = pkg['nameForCLI'] || pkg.name!;
+        const prefix = pkg['appLoggerPrefix'] || pkg.name!;
         return new SimpleLogger({ prefix, ...rest });
       });
     },

--- a/packages/public/simple-logger/tests/.eslintrc.js
+++ b/packages/public/simple-logger/tests/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: 'tsconfig.json',
+    sourceType: 'module',
+  },
+  plugins: ['@homer0'],
+  extends: [
+    'plugin:@homer0/node-typescript-with-prettier',
+    'plugin:@homer0/jest-with-prettier',
+  ],
+  ignorePatterns: ['.eslintrc.js'],
+  globals: {
+    fetch: true,
+  },
+  rules: {
+    'import/no-extraneous-dependencies': 'off',
+    'node/no-extraneous-import': 'off',
+  },
+};

--- a/packages/public/simple-logger/tests/index.test.ts
+++ b/packages/public/simple-logger/tests/index.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable max-classes-per-file */
 // eslint-disable-next-line global-require
 jest.mock('colors/safe', () => require('./mocks/colors'));
+jest.mock('@homer0/package-info');
 jest.unmock('../src');
 
 import colorsOriginal from 'colors/safe';
@@ -387,7 +388,7 @@ describe('SimpleLogger', () => {
       expect(sut.prefix).toBe(pkgJson.name);
     });
 
-    it('should use nameForCLI instead of the package name', () => {
+    it('should use appLoggerPrefix instead of the package name', () => {
       // Given
       const getFn = jest.fn();
       const setFn = jest.fn();
@@ -409,7 +410,7 @@ describe('SimpleLogger', () => {
       });
       const pkgJson = {
         name: 'my-app',
-        nameForCLI: 'my-cli-app',
+        appLoggerPrefix: 'my-cli-app',
       };
       jest.spyOn(usePackageInfo, 'getSync').mockReturnValueOnce(pkgJson);
       const container = new Container({
@@ -427,7 +428,7 @@ describe('SimpleLogger', () => {
       // Then
       expect(serviceName).toBe('appLogger');
       expect(sut).toBeInstanceOf(SimpleLogger);
-      expect(sut.prefix).toBe(pkgJson.nameForCLI);
+      expect(sut.prefix).toBe(pkgJson.appLoggerPrefix);
     });
 
     it('should create the services to inject if they are not available', () => {

--- a/packages/public/simple-logger/tests/index.test.ts
+++ b/packages/public/simple-logger/tests/index.test.ts
@@ -1,0 +1,515 @@
+/* eslint-disable no-console */
+/* eslint-disable max-classes-per-file */
+// eslint-disable-next-line global-require
+jest.mock('colors/safe', () => require('./mocks/colors'));
+jest.unmock('../src');
+
+import colorsOriginal from 'colors/safe';
+import { Jimple } from '@homer0/jimple';
+import { PathUtils } from '@homer0/path-utils';
+import { PackageInfo, packageInfo as originalPackageInfo } from '@homer0/package-info';
+import {
+  SimpleLogger,
+  simpleLogger,
+  simpleLoggerProvider,
+  appLoggerProvider,
+  type SimpleLoggerMessage,
+} from '../src';
+
+const originalConsoleLog = console.log;
+
+const colors = colorsOriginal as jest.Mocked<typeof colorsOriginal> & {
+  clear: () => void;
+};
+
+type PackageInfoFn = typeof originalPackageInfo;
+const packageInfo = originalPackageInfo as jest.Mock<ReturnType<PackageInfoFn>>;
+
+describe('SimpleLogger', () => {
+  describe('class', () => {
+    beforeEach(() => {
+      console.log = originalConsoleLog;
+      colors.clear();
+    });
+
+    it('should be instantiated', () => {
+      // Given/When
+      const sut = new SimpleLogger();
+      // Then
+      expect(sut).toBeInstanceOf(SimpleLogger);
+    });
+
+    it('should be instantiated with custom options', () => {
+      // Given
+      const options = { prefix: 'test', showTime: true };
+      // When
+      const sut = new SimpleLogger(options);
+      // Then
+      expect(sut).toBeInstanceOf(SimpleLogger);
+      expect(sut.prefix).toBe(options.prefix);
+      expect(sut.showTime).toBe(options.showTime);
+    });
+
+    it('should log a message', () => {
+      // Given
+      const message = 'hello world';
+      const logFn = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(logFn);
+      // When
+      const sut = new SimpleLogger();
+      sut.log(message);
+      // Then
+      expect(logFn).toHaveBeenCalledTimes(1);
+      expect(logFn).toHaveBeenCalledWith(message);
+    });
+
+    it('should log a message with a prefix', () => {
+      // Given
+      const prefix = 'my-app';
+      const message = 'hello world';
+      const logFn = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(logFn);
+      // When
+      const sut = new SimpleLogger({ prefix });
+      sut.log(message);
+      // Then
+      expect(logFn).toHaveBeenCalledTimes(1);
+      expect(logFn).toHaveBeenCalledWith(`[${prefix}] ${message}`);
+    });
+
+    it('should log a message with the time', () => {
+      // Given
+      const now = new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '');
+      const message = 'hello world';
+      const logFn = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(logFn);
+      // When
+      const sut = new SimpleLogger({ showTime: true });
+      sut.log(message);
+      // Then
+      expect(logFn).toHaveBeenCalledTimes(1);
+      expect(logFn).toHaveBeenCalledWith(`[${now}] ${message}`);
+    });
+
+    it('should log a colored message', () => {
+      // Given
+      const message = 'hello world';
+      const color = 'red';
+      const logFn = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(logFn);
+      // // When
+      const sut = new SimpleLogger();
+      sut.log(message, color);
+      // // Then
+      expect(logFn).toHaveBeenCalledTimes(1);
+      expect(logFn).toHaveBeenCalledWith(message);
+      expect(colors[color]).toHaveBeenCalledTimes(1);
+      expect(colors[color]).toHaveBeenCalledWith(message);
+    });
+
+    it('should log a list of messages', () => {
+      // Given
+      const messages = ['hello world', 'goodbye world'];
+      const log = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(log);
+      // When
+      const sut = new SimpleLogger();
+      sut.log(messages);
+      // Then
+      expect(log).toHaveBeenCalledTimes(messages.length);
+      messages.forEach((message) => {
+        expect(log).toHaveBeenCalledWith(message);
+      });
+    });
+
+    it('should log a list of colored messages', () => {
+      // Given
+      const messages = ['hello world', 'goodbye world'];
+      const color = 'blue';
+      const log = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(log);
+      // When
+      const sut = new SimpleLogger();
+      sut.log(messages, color);
+      // Then
+      expect(log).toHaveBeenCalledTimes(messages.length);
+      expect(colors[color]).toHaveBeenCalledTimes(messages.length);
+      messages.forEach((message) => {
+        expect(log).toHaveBeenCalledWith(message);
+        expect(colors[color]).toHaveBeenCalledWith(message);
+      });
+    });
+
+    it('should log a list messages with different colors', () => {
+      // Given
+      const messages: SimpleLoggerMessage = [
+        ['hello world', 'green'],
+        ['goodbye world', 'yellow'],
+      ];
+      const log = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(log);
+      // When
+      const sut = new SimpleLogger();
+      sut.log(messages);
+      // Then
+      expect(log).toHaveBeenCalledTimes(messages.length);
+      messages.forEach((line) => {
+        const [message, color] = line as [string, keyof typeof colors];
+        expect(log).toHaveBeenCalledWith(message);
+        expect(colors[color]).toHaveBeenCalledWith(message);
+      });
+    });
+
+    it('should log a warning message (yellow)', () => {
+      // Given
+      const message = 'Something is not working';
+      const color = 'yellow';
+      const log = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(log);
+      // When
+      const sut = new SimpleLogger();
+      sut.warn(message);
+      // Then
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log).toHaveBeenCalledWith(message);
+      expect(colors[color]).toHaveBeenCalledTimes(1);
+      expect(colors[color]).toHaveBeenCalledWith(message);
+    });
+
+    it('should log a success message (green)', () => {
+      // Given
+      const message = 'Everything works!';
+      const color = 'green';
+      const log = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(log);
+      // When
+      const sut = new SimpleLogger();
+      sut.success(message);
+      // Then
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log).toHaveBeenCalledWith(message);
+      expect(colors[color]).toHaveBeenCalledTimes(1);
+      expect(colors[color]).toHaveBeenCalledWith(message);
+    });
+
+    it('should log an informative message (grey)', () => {
+      // Given
+      const message = 'Be aware of the Batman';
+      const color = 'grey';
+      const log = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(log);
+      // When
+      const sut = new SimpleLogger();
+      sut.info(message);
+      // Then
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log).toHaveBeenCalledWith(message);
+      expect(colors[color]).toHaveBeenCalledTimes(1);
+      expect(colors[color]).toHaveBeenCalledWith(message);
+    });
+
+    it('should log an error message (red)', () => {
+      // Given
+      const message = 'Something went terribly wrong';
+      const color = 'red';
+      const log = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(log);
+      // When
+      const sut = new SimpleLogger();
+      sut.error(message);
+      // Then
+      expect(log).toHaveBeenCalledTimes(1);
+      expect(log).toHaveBeenCalledWith(message);
+      expect(colors[color]).toHaveBeenCalledTimes(1);
+      expect(colors[color]).toHaveBeenCalledWith(message);
+    });
+
+    it('should log an error message (red) and include an exception information', () => {
+      // Given
+      const message = 'Something went terribly wrong';
+      const exception = 'ORDER 66';
+      const color = 'red';
+      const log = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(log);
+      // When
+      const sut = new SimpleLogger();
+      sut.error(message, exception);
+      // Then
+      expect(log).toHaveBeenCalledTimes(2);
+      expect(log).toHaveBeenNthCalledWith(1, message);
+      expect(log).toHaveBeenNthCalledWith(2, exception);
+      expect(colors[color]).toHaveBeenCalledTimes(1);
+      expect(colors[color]).toHaveBeenCalledWith(message);
+    });
+
+    it('should log an error message (red) and include an error exception stack', () => {
+      // Given
+      const message = 'Something went terribly wrong';
+      const exception = new Error('ORDER 66');
+      const stack = exception.stack!.split('\n').map((line) => line.trim());
+      stack.splice(0, 1);
+      const errorColor = 'red';
+      const stackColor = 'grey';
+      const log = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(log);
+      // When
+      const sut = new SimpleLogger();
+      sut.error(message, exception);
+      // Then
+      expect(log).toHaveBeenCalledTimes(stack.length + 1);
+      expect(log).toHaveBeenCalledWith(message);
+      stack.forEach((line) => {
+        expect(log).toHaveBeenCalledWith(line);
+      });
+
+      expect(colors[errorColor]).toHaveBeenCalledTimes(1);
+      expect(colors[stackColor]).toHaveBeenCalledTimes(stack.length);
+    });
+
+    it('should log an exception error and its stack', () => {
+      // Given
+      const exception = new Error('ORDER 66');
+      const stack = exception.stack!.split('\n').map((line) => line.trim());
+      stack.splice(0, 1);
+      const errorColor = 'red';
+      const stackColor = 'grey';
+      const log = jest.fn();
+      jest.spyOn(console, 'log').mockImplementation(log);
+      // When
+      const sut = new SimpleLogger();
+      sut.error(exception);
+      // Then
+      expect(log).toHaveBeenCalledTimes(stack.length + 1);
+      expect(log).toHaveBeenCalledWith(exception.message);
+      stack.forEach((line) => {
+        expect(log).toHaveBeenCalledWith(line);
+      });
+
+      expect(colors[errorColor]).toHaveBeenCalledTimes(1);
+      expect(colors[stackColor]).toHaveBeenCalledTimes(stack.length);
+    });
+  });
+
+  describe('shorthand', () => {
+    it('should have a shorthand function', () => {
+      // Given/When/Then
+      expect(simpleLogger()).toBeInstanceOf(SimpleLogger);
+    });
+  });
+
+  describe('provider', () => {
+    it('should include a Jimple provider', () => {
+      // Given
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const container = new Container();
+      // When
+      simpleLoggerProvider.register(container);
+      const [[serviceName, serviceFn]] = setFn.mock.calls as [
+        [string, () => SimpleLogger],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(serviceName).toBe('simpleLogger');
+      expect(sut).toBeInstanceOf(SimpleLogger);
+    });
+
+    it('should allow custom options on its provider', () => {
+      // Given
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const container = new Container();
+      const providerServiceName = 'mySimpleLogger';
+      // When
+      simpleLoggerProvider({
+        serviceName: providerServiceName,
+      }).register(container);
+      const [[serviceName, serviceFn]] = setFn.mock.calls as [
+        [string, () => SimpleLogger],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(serviceName).toBe(providerServiceName);
+      expect(sut).toBeInstanceOf(SimpleLogger);
+    });
+  });
+
+  describe('appLogger provider', () => {
+    it('should register the service with the app name as prefix', () => {
+      // Given
+      const getFn = jest.fn();
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override get<T>(key: string): T {
+          getFn(key);
+          return super.get<T>(key);
+        }
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const usePathUtils = new PathUtils();
+      const usePackageInfo = new PackageInfo({
+        inject: {
+          pathUtils: usePathUtils,
+        },
+      });
+      const pkgJson = {
+        name: 'my-app',
+      };
+      jest.spyOn(usePackageInfo, 'getSync').mockReturnValueOnce(pkgJson);
+      const container = new Container({
+        pathUtils: usePathUtils,
+        packageInfo: usePackageInfo,
+      });
+      // When
+      appLoggerProvider.register(container);
+      const [, , [serviceName, serviceFn]] = setFn.mock.calls as [
+        unknown,
+        unknown,
+        [string, () => SimpleLogger],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(serviceName).toBe('appLogger');
+      expect(sut).toBeInstanceOf(SimpleLogger);
+      expect(sut.prefix).toBe(pkgJson.name);
+    });
+
+    it('should use nameForCLI instead of the package name', () => {
+      // Given
+      const getFn = jest.fn();
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override get<T>(key: string): T {
+          getFn(key);
+          return super.get<T>(key);
+        }
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const usePathUtils = new PathUtils();
+      const usePackageInfo = new PackageInfo({
+        inject: {
+          pathUtils: usePathUtils,
+        },
+      });
+      const pkgJson = {
+        name: 'my-app',
+        nameForCLI: 'my-cli-app',
+      };
+      jest.spyOn(usePackageInfo, 'getSync').mockReturnValueOnce(pkgJson);
+      const container = new Container({
+        pathUtils: usePathUtils,
+        packageInfo: usePackageInfo,
+      });
+      // When
+      appLoggerProvider.register(container);
+      const [, , [serviceName, serviceFn]] = setFn.mock.calls as [
+        unknown,
+        unknown,
+        [string, () => SimpleLogger],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(serviceName).toBe('appLogger');
+      expect(sut).toBeInstanceOf(SimpleLogger);
+      expect(sut.prefix).toBe(pkgJson.nameForCLI);
+    });
+
+    it('should create the services to inject if they are not available', () => {
+      // Given
+      const getFn = jest.fn();
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override get<T>(key: string): T {
+          getFn(key);
+          return super.get<T>(key);
+        }
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const usePackageInfo = new PackageInfo();
+      const pkgJson = {
+        name: 'my-app',
+      };
+      jest.spyOn(usePackageInfo, 'getSync').mockReturnValueOnce(pkgJson);
+      packageInfo.mockReturnValueOnce(usePackageInfo);
+      const container = new Container();
+      // When
+      appLoggerProvider.register(container);
+      const [[serviceName, serviceFn]] = setFn.mock.calls as [
+        [string, () => SimpleLogger],
+      ];
+      const sut = serviceFn();
+      // // Then
+      expect(serviceName).toBe('appLogger');
+      expect(sut).toBeInstanceOf(SimpleLogger);
+      expect(sut.prefix).toBe(pkgJson.name);
+    });
+
+    it('should register the service with custom options', () => {
+      // Given
+      const getFn = jest.fn();
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override get<T>(key: string): T {
+          getFn(key);
+          return super.get<T>(key);
+        }
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const usePathUtils = new PathUtils();
+      const usePackageInfo = new PackageInfo({
+        inject: {
+          pathUtils: usePathUtils,
+        },
+      });
+      const pkgJson = {
+        name: 'my-app',
+      };
+      jest.spyOn(usePackageInfo, 'getSync').mockReturnValueOnce(pkgJson);
+      const container = new Container({
+        myPathUtils: usePathUtils,
+        myPackageInfo: usePackageInfo,
+      });
+      const providerServiceName = 'myAppLogger';
+      // When
+      appLoggerProvider({
+        serviceName: providerServiceName,
+        services: {
+          pathUtils: 'myPathUtils',
+          packageInfo: 'myPackageInfo',
+        },
+      }).register(container);
+      const [, , [serviceName, serviceFn]] = setFn.mock.calls as [
+        unknown,
+        unknown,
+        [string, () => SimpleLogger],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(serviceName).toBe(providerServiceName);
+      expect(sut).toBeInstanceOf(SimpleLogger);
+      expect(sut.prefix).toBe(pkgJson.name);
+    });
+  });
+});

--- a/packages/public/simple-logger/tests/mocks/colors.js
+++ b/packages/public/simple-logger/tests/mocks/colors.js
@@ -1,0 +1,28 @@
+const colors = [
+  'black',
+  'red',
+  'green',
+  'yellow',
+  'blue',
+  'magenta',
+  'cyan',
+  'white',
+  'gray',
+  'grey',
+];
+
+const mocks = colors.reduce((acc, color) => {
+  acc[color] = jest.fn((str) => str);
+  return acc;
+}, {});
+
+const clear = () =>
+  colors.forEach((color) => {
+    mocks[color].mockClear();
+  });
+
+module.exports = {
+  mocks,
+  clear,
+  ...mocks,
+};

--- a/packages/public/simple-logger/tests/tsconfig.json
+++ b/packages/public/simple-logger/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@homer0/tsconfig/tsconfig.node.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "strict": true,
+    "noImplicitAny": true,
+    "resolveJsonModule": true
+  },
+  "include": ["./"]
+}

--- a/packages/public/simple-logger/tsconfig.json
+++ b/packages/public/simple-logger/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@homer0/tsconfig/tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "emitDecoratorMetadata": false,
+    "incremental": false
+  },
+  "include": ["src/**/*.ts", "tsup.config.ts"]
+}

--- a/packages/public/simple-logger/tsup.config.ts
+++ b/packages/public/simple-logger/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  sourcemap: true,
+  clean: true,
+  format: ['esm', 'cjs'],
+  legacyOutput: true,
+  dts: true,
+});

--- a/packages/public/simple-logger/tsup.config.ts
+++ b/packages/public/simple-logger/tsup.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   legacyOutput: true,
   dts: true,
+  bundle: false,
 });

--- a/utils/scripts/build
+++ b/utils/scripts/build
@@ -14,3 +14,4 @@ buildPkg path-utils;
 buildPkg package-info;
 buildPkg env-utils;
 buildPkg root-file;
+buildPkg simple-logger;

--- a/utils/scripts/types-check
+++ b/utils/scripts/types-check
@@ -1,0 +1,2 @@
+#!/bin/bash -e
+lerna run types:check $@

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,6 +2802,11 @@ colorette@^2.0.16:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.17.tgz#5dd4c0d15e2984b7433cb4a9f2ead45063b80c47"
   integrity sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g==
 
+colors@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 columnify@^1.5.4:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.6.0.tgz#6989531713c9008bb29735e61e37acf5bd553cf3"


### PR DESCRIPTION
### What does this PR do?

It migrates the `Logger` module from `wootils` into its own package.

I also took the opportunity to move it to TypeScript.

Besides that, I added missing docs on the other packages, disabled bundling for Node packages, and added type validation.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```