### PR TITLE
New package: error-handler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,6 +144,15 @@ jobs:
           flag-name: public-simple-logger
           path-to-lcov: ./packages/public/simple-logger/coverage/lcov.info
           base-path: ./packages/public/simple-logger
+      - name: Coveralls for public/error-handler
+        if: ${{ matrix.node == '14' }}
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
+          flag-name: public-error-handler
+          path-to-lcov: ./packages/public/error-handler/coverage/lcov.info
+          base-path: ./packages/public/error-handler
 
   finish:
       needs: build

--- a/packages/public/error-handler/.eslintrc.js
+++ b/packages/public/error-handler/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: 'tsconfig.json',
+    sourceType: 'module',
+  },
+  plugins: ['@homer0'],
+  extends: ['plugin:@homer0/node-typescript-with-prettier'],
+  ignorePatterns: ['.eslintrc.js', 'dist/'],
+  rules: {
+    'node/no-extraneous-import': [
+      'error',
+      {
+        allowModules: ['@homer0/jimple', '@homer0/simple-logger'],
+      },
+    ],
+  },
+};

--- a/packages/public/error-handler/.jestrc.js
+++ b/packages/public/error-handler/.jestrc.js
@@ -8,7 +8,7 @@ module.exports = {
   automock: true,
   collectCoverage: true,
   testPathIgnorePatterns: ['/node_modules/'],
-  unmockedModulePathPatterns: ['/node_modules/', 'jimple', 'path-utils'],
+  unmockedModulePathPatterns: ['/node_modules/', 'jimple', 'simple-logger'],
   testEnvironment: 'node',
   globals: {
     'ts-jest': {

--- a/packages/public/error-handler/.jestrc.js
+++ b/packages/public/error-handler/.jestrc.js
@@ -1,0 +1,18 @@
+const path = require('path');
+
+/**
+ * @type {import('ts-jest').InitialOptionsTsJest}
+ */
+module.exports = {
+  preset: 'ts-jest',
+  automock: true,
+  collectCoverage: true,
+  testPathIgnorePatterns: ['/node_modules/'],
+  unmockedModulePathPatterns: ['/node_modules/', 'jimple', 'path-utils'],
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      tsconfig: path.join(__dirname, 'tests', 'tsconfig.json'),
+    },
+  },
+};

--- a/packages/public/error-handler/README.md
+++ b/packages/public/error-handler/README.md
@@ -1,0 +1,98 @@
+# 💥 Error handler
+
+Listens for uncaught exceptions and unhandled promises rejections, and logs them out with full detail.
+
+By default, if an error is thrown, node will just output the error, but if a `Promise` is rejected and there's no `catch` to capture the exception, it will log `...`, which doesn't provide a lot of information, right?
+
+Well, `ErrorHandler` listens for these kind of exceptions, unhandled errors and rejected promises, and logs them with their stack trace information using the `Logger` utility.
+
+## 🍿 Usage
+
+- ⚙️ [Examples](#%EF%B8%8F-examples)
+- 🤘 [Development](#-development)
+
+### ⚙️ Example
+
+```ts
+import { errorHandler } from '@homer0/error-handler';
+
+const handler = errorHandler();
+
+// ...
+
+handler.listen();
+```
+
+Now, if something like an API call without a `catch` would throw an error, you'll see the error logged like this:
+
+```bash
+[2018-01-22 04:19:12] 401
+at makeAPICall (/path-to-your-app/index.js:9:42)
+at Object.<anonymous> (/path-to-your-app/index.js:11:1)
+at Module._compile (module.js:570:32)
+at Object.Module._extensions..js (module.js:579:10)
+at Module.load (module.js:487:32)
+at tryModuleLoad (module.js:446:12)
+at Function.Module._load (module.js:438:3)
+at Module.runMain (module.js:604:10)
+at run (bootstrap_node.js:383:7)
+at startup (bootstrap_node.js:149:9)
+```
+
+Date an time, and full stack trace information (with colors!).
+
+#### Jimple provider
+
+If your app uses a [Jimple container](https://npmjs.com/package/jimple), you can register `ErrorHandler` as the `errorHandler` service by using its provider:
+
+```ts
+import { errorHandlerProvider } from '@homer0/error-handler';
+
+// ...
+
+container.register(errorHandlerProvider);
+
+// ...
+
+const handler = container.get('errorHandler');
+```
+
+And since the provider is a "provider creator" (created with [my custom version of Jimple](https:///npmjs.com/package/@homer0/jimple)), you can customize its service name:
+
+```ts
+container.register(
+  errorHandlerProvider({
+    serviceName: 'myErrorHandler',
+  }),
+);
+```
+
+##### Dependencies
+
+`ErrorHandler` depends on the following services, and when used with Jimple, it will try to find them in the container, otherwise, it will create new instances:
+
+- [`@homer0/simple-logger`](https://npmjs.com/package/@homer0/simple-logger), with the name `appLogger` or `simpleLogger`. Used to generate log the messages in the console.
+
+If you already implement the dependencies, but with a different name, you can specify them in the provider:
+
+```ts
+container.register(
+  errorHandlerProvider({
+    services: {
+      simpleLogger: 'mySimpleLogger',
+      // or `appLogger: 'myAppLogger',`
+    },
+  }),
+);
+```
+
+### 🤘 Development
+
+As this project is part of the `packages` monorepo, it requires Yarn, and some of the tooling, like ESLint and Husky, are installed on the root's `package.json`.
+
+#### Yarn tasks
+
+| Task    | Description          |
+| ------- | -------------------- |
+| `test`  | Runs the unit tests. |
+| `build` | Bundles the project. |

--- a/packages/public/error-handler/package.json
+++ b/packages/public/error-handler/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@homer0/error-handler",
+  "description": "Captures uncaught exceptions and unhandled rejections in order to log them to the console",
+  "version": "0.0.0-development",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/homer0/packages.git",
+    "directory": "packages/public/error-handler"
+  },
+  "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
+  "license": "MIT",
+  "keywords": [
+    "node",
+    "error",
+    "utility",
+    "wootils",
+    "javascript"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist/"
+  ],
+  "dependencies": {
+    "@homer0/jimple": "^0.0.0-development",
+    "@homer0/simple-logger": "^0.0.0-development"
+  },
+  "devDependencies": {
+    "@types/jest": "^28.1.1",
+    "jest": "^28.1.1",
+    "ts-jest": "^28.0.4",
+    "tsup": "^6.1.2",
+    "typescript": "^4.7.3"
+  },
+  "engine-strict": true,
+  "engines": {
+    "node": ">=14"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "test": "jest -c ./.jestrc.js",
+    "types:check": "tsc --noEmit",
+    "build": "tsup src/index.ts",
+    "prepublishOnly": "npm run build"
+  }
+}

--- a/packages/public/error-handler/src/index.ts
+++ b/packages/public/error-handler/src/index.ts
@@ -1,0 +1,152 @@
+import { simpleLogger, type SimpleLogger } from '@homer0/simple-logger';
+import { providerCreator, injectHelper } from '@homer0/jimple';
+/**
+ * The dictionary of dependencies that need to be injected in {@link ErrorHandler}.
+ */
+type ErrorHandlerInjectOptions = {
+  /**
+   * The service that logs the messages on the console.
+   */
+  simpleLogger: SimpleLogger;
+  /**
+   * An alternative to the regular logger, with the project name.
+   */
+  appLogger: SimpleLogger;
+};
+/**
+ * The inject helper to resolve the dependencies.
+ */
+const deps = injectHelper<ErrorHandlerInjectOptions>();
+/**
+ * The options for the service constructor.
+ */
+export type ErrorHandlerOptions = {
+  /**
+   * A dictionary with the dependency injections for the service. If one or more are not
+   * provided, the service will create new instances.
+   */
+  inject?: Partial<ErrorHandlerInjectOptions>;
+  /**
+   * Whether or not to exit the process after receiving an error.
+   *
+   * @default true
+   */
+  exitOnError?: boolean;
+};
+/**
+ * A small service that reads the contents of the implementation's package.json file.
+ */
+export class ErrorHandler {
+  /**
+   * Used to log the errors on the console.
+   */
+  protected logger: SimpleLogger;
+  /**
+   * Whether or not to exit the process after receiving an error.
+   */
+  readonly exitOnError: boolean;
+  /**
+   * The list of events this handler will listen for in order to catch errors.
+   */
+  protected eventNames: string[] = ['uncaughtException', 'unhandledRejection'];
+  constructor({ inject = {}, exitOnError = true }: ErrorHandlerOptions = {}) {
+    this.logger = deps.get(inject, 'simpleLogger', () => simpleLogger());
+    this.exitOnError = exitOnError;
+    this.handle = this.handle.bind(this);
+    this.stopListening = this.stopListening.bind(this);
+  }
+  /**
+   * Starts listening for unhandled errors.
+   *
+   * @returns A function to stop listing (a reference for
+   *          {@link ErrorHandler.stopListening}).
+   */
+  listen() {
+    this.eventNames.forEach((eventName) => {
+      process.on(eventName, this.handle);
+    });
+
+    return this.stopListening;
+  }
+  /**
+   * Stops listening for unhandled errors.
+   */
+  stopListening() {
+    this.eventNames.forEach((eventName) => {
+      process.removeListener(eventName, this.handle);
+    });
+  }
+  /**
+   * This is called by the process listeners when an uncaught exception is thrown or a
+   * rejected promise is not handled. It logs the error on detail.
+   * The process exits when after logging an error.
+   *
+   * @param error  The unhandled error.
+   */
+  handle(error: Error) {
+    // If the logger is configured to show the time...
+    if (this.logger.showTime) {
+      // ...just send the error.
+      this.logger.error(error);
+    } else {
+      // ...otherwise, get the time on a readable format.
+      const time = new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '');
+      // Build the error message with the time.
+      const message = `[${time}] ${error.message}`;
+      // Log the new message with the exception.
+      this.logger.error(message, error);
+    }
+
+    // Check if it should exit the process.
+    if (this.exitOnError) {
+      // eslint-disable-next-line no-process-exit
+      process.exit(1);
+    }
+  }
+}
+/**
+ * Shorthand for `new ErrorHandler()`.
+ *
+ * @param args  The same parameters as the {@link ErrorHandler} constructor.
+ * @returns A new instance of {@link ErrorHandler}.
+ */
+export const errorHandler = (
+  ...args: ConstructorParameters<typeof ErrorHandler>
+): ErrorHandler => new ErrorHandler(...args);
+
+/**
+ * The options for the {@link ErrorHandler} Jimple's provider creator.
+ */
+export type ErrorHandlerProviderOptions = Omit<ErrorHandlerOptions, 'inject'> & {
+  /**
+   * The name that will be used to register the service.
+   *
+   * @default 'errorHandler'
+   */
+  serviceName?: string;
+  /**
+   * A dictionary with the name of the services to inject. If one or more are not
+   * provided, the service will create new instances.
+   */
+  services?: {
+    [key in keyof ErrorHandlerInjectOptions]?: string;
+  };
+};
+/**
+ * A provider creator to register {@link ErrorHandler} in a Jimple container.
+ */
+export const errorHandlerProvider = providerCreator(
+  ({ serviceName = 'errorHandler', ...rest }: ErrorHandlerProviderOptions = {}) =>
+    (container) => {
+      container.set(serviceName, () => {
+        const { services = {}, ...options } = rest;
+        const inject = deps.resolve(['simpleLogger', 'appLogger'], container, services);
+        if (inject.appLogger) {
+          delete inject.simpleLogger;
+          inject.simpleLogger = inject.appLogger;
+        }
+
+        return new ErrorHandler({ inject, ...options });
+      });
+    },
+);

--- a/packages/public/error-handler/tests/.eslintrc.js
+++ b/packages/public/error-handler/tests/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: 'tsconfig.json',
+    sourceType: 'module',
+  },
+  plugins: ['@homer0'],
+  extends: [
+    'plugin:@homer0/node-typescript-with-prettier',
+    'plugin:@homer0/jest-with-prettier',
+  ],
+  ignorePatterns: ['.eslintrc.js'],
+  globals: {
+    fetch: true,
+  },
+  rules: {
+    'import/no-extraneous-dependencies': 'off',
+    'node/no-extraneous-import': 'off',
+  },
+};

--- a/packages/public/error-handler/tests/index.test.ts
+++ b/packages/public/error-handler/tests/index.test.ts
@@ -1,0 +1,294 @@
+/* eslint-disable max-classes-per-file */
+jest.unmock('../src');
+
+import { Jimple } from '@homer0/jimple';
+import { SimpleLogger } from '@homer0/simple-logger';
+import { ErrorHandler, errorHandler, errorHandlerProvider } from '../src';
+
+const originalProcessOn = process.on;
+const originalProcessRemoveListener = process.removeListener;
+const originalExit = process.exit;
+
+describe('ErrorHandler', () => {
+  describe('class', () => {
+    afterEach(() => {
+      process.on = originalProcessOn;
+      process.removeListener = originalProcessRemoveListener;
+      process.exit = originalExit;
+    });
+
+    it('should be instantiated', () => {
+      // Given/When
+      const sut = new ErrorHandler();
+      // Then
+      expect(sut).toBeInstanceOf(ErrorHandler);
+    });
+
+    it('should be instantiated with custom options', () => {
+      // Given
+      const exitOnError = false;
+      // When
+      const sut = new ErrorHandler({ exitOnError });
+      // Then
+      expect(sut).toBeInstanceOf(ErrorHandler);
+      expect(sut.exitOnError).toBe(exitOnError);
+    });
+
+    it('should add the listeners for uncaught and rejected exceptions', () => {
+      // Given
+      const onMock = jest.fn();
+      process.on = onMock;
+      // When
+      const sut = new ErrorHandler();
+      sut.listen();
+      // Then
+      expect(onMock).toHaveBeenCalledTimes(2);
+      expect(onMock).toHaveBeenNthCalledWith(
+        1,
+        'uncaughtException',
+        expect.any(Function),
+      );
+      expect(onMock).toHaveBeenNthCalledWith(
+        2,
+        'unhandledRejection',
+        expect.any(Function),
+      );
+    });
+
+    it('should add and remove the listeners for uncaught and rejected exceptions', () => {
+      // Given
+      const onMock = jest.fn();
+      process.on = onMock;
+      const removeListenerMock = jest.fn();
+      process.removeListener = removeListenerMock;
+      // When
+      const sut = new ErrorHandler();
+      sut.listen();
+      sut.stopListening();
+      // Then
+      expect(onMock).toHaveBeenCalledTimes(2);
+      expect(removeListenerMock).toHaveBeenCalledTimes(2);
+      expect(removeListenerMock).toHaveBeenNthCalledWith(
+        1,
+        'uncaughtException',
+        expect.any(Function),
+      );
+      expect(removeListenerMock).toHaveBeenNthCalledWith(
+        2,
+        'unhandledRejection',
+        expect.any(Function),
+      );
+    });
+
+    it('should log an uncaught exception as it is if the logger already shows time', () => {
+      // Given
+      const exitMock = jest.fn();
+      // @ts-expect-error - Because we are overwriting the default process.
+      process.exit = exitMock;
+      const logMock = jest.fn();
+      class AppLogger extends SimpleLogger {
+        override error(...args: Parameters<SimpleLogger['error']>) {
+          logMock(...args);
+        }
+      }
+      const appLogger = new AppLogger({ showTime: true });
+      const exception = new Error('ORDER 66');
+      // When
+      const sut = new ErrorHandler({
+        inject: {
+          simpleLogger: appLogger,
+        },
+      });
+      sut.handle(exception);
+      // Then
+      expect(logMock).toHaveBeenCalledTimes(1);
+      expect(logMock).toHaveBeenCalledWith(exception);
+      expect(exitMock).toHaveBeenCalledTimes(1);
+      expect(exitMock).toHaveBeenCalledWith(1);
+    });
+
+    it('should log an uncaught exception with the time if the logger has it disabled', () => {
+      // Given
+      const exitMock = jest.fn();
+      // @ts-expect-error - Because we are overwriting the default process.
+      process.exit = exitMock;
+      const logMock = jest.fn();
+      class AppLogger extends SimpleLogger {
+        override error(...args: Parameters<SimpleLogger['error']>) {
+          logMock(...args);
+        }
+      }
+      const appLogger = new AppLogger({ showTime: false });
+      const exception = new Error('ORDER 66');
+      // When
+      const sut = new ErrorHandler({
+        inject: {
+          simpleLogger: appLogger,
+        },
+      });
+      sut.handle(exception);
+      // Then
+      expect(logMock).toHaveBeenCalledTimes(1);
+      expect(logMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^\[\d+-\d+-\d+ \d+:\d+:\d+]/),
+        exception,
+      );
+      expect(exitMock).toHaveBeenCalledTimes(1);
+      expect(exitMock).toHaveBeenCalledWith(1);
+    });
+
+    it("shouldn't exit the process when handling an error", () => {
+      // Given
+      const exitMock = jest.fn();
+      // @ts-expect-error - Because we are overwriting the default process.
+      process.exit = exitMock;
+      const logMock = jest.fn();
+      class AppLogger extends SimpleLogger {
+        override error(...args: Parameters<SimpleLogger['error']>) {
+          logMock(...args);
+        }
+      }
+      const appLogger = new AppLogger({ showTime: true });
+      const exception = new Error('ORDER 66');
+      // When
+      const sut = new ErrorHandler({
+        inject: {
+          simpleLogger: appLogger,
+        },
+        exitOnError: false,
+      });
+      sut.handle(exception);
+      // Then
+      expect(logMock).toHaveBeenCalledTimes(1);
+      expect(logMock).toHaveBeenCalledWith(exception);
+      expect(exitMock).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('shorthand', () => {
+    it('should have a shorthand function', () => {
+      // Given/When/Then
+      expect(errorHandler()).toBeInstanceOf(ErrorHandler);
+    });
+  });
+
+  describe('provider', () => {
+    it('should include a Jimple provider', () => {
+      // Given
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const container = new Container();
+      // When
+      errorHandlerProvider.register(container);
+      const [[serviceName, serviceFn]] = setFn.mock.calls as [
+        [string, () => ErrorHandler],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(serviceName).toBe('errorHandler');
+      expect(sut).toBeInstanceOf(ErrorHandler);
+    });
+
+    it('should allow custom options on its provider', () => {
+      // Given
+      const getFn = jest.fn();
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override get<T>(key: string): T {
+          getFn(key);
+          return super.get<T>(key);
+        }
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const container = new Container({
+        logger: new SimpleLogger(),
+      });
+      const providerServiceName = 'myErrorHandler';
+      // When
+      errorHandlerProvider({
+        serviceName: providerServiceName,
+      }).register(container);
+      const [, [serviceName, serviceFn]] = setFn.mock.calls as [
+        unknown,
+        [string, () => ErrorHandler],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(serviceName).toBe(providerServiceName);
+      expect(sut).toBeInstanceOf(ErrorHandler);
+    });
+
+    it('should allow custom services on its provider', () => {
+      // Given
+      const getFn = jest.fn();
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override get<T>(key: string): T {
+          getFn(key);
+          return super.get<T>(key);
+        }
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      class MySimpleLogger extends SimpleLogger {}
+      const container = new Container({
+        mySimpleLogger: new MySimpleLogger(),
+      });
+      const providerServiceName = 'myErrorHandler';
+      // When
+      errorHandlerProvider({
+        serviceName: providerServiceName,
+        services: {
+          simpleLogger: 'mySimpleLogger',
+        },
+      }).register(container);
+      const [, [serviceName, serviceFn]] = setFn.mock.calls as [
+        unknown,
+        [string, () => ErrorHandler],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(serviceName).toBe(providerServiceName);
+      expect(sut).toBeInstanceOf(ErrorHandler);
+      expect(getFn).toHaveBeenCalledWith('mySimpleLogger');
+    });
+
+    it('should use the app logger if available', () => {
+      // Given
+      const getFn = jest.fn();
+      const setFn = jest.fn();
+      class Container extends Jimple {
+        override get<T>(key: string): T {
+          getFn(key);
+          return super.get<T>(key);
+        }
+        override set(...args: Parameters<Jimple['set']>) {
+          setFn(...args);
+          super.set(...args);
+        }
+      }
+      const container = new Container({
+        appLogger: new SimpleLogger(),
+      });
+      // When
+      errorHandlerProvider().register(container);
+      const [, [, serviceFn]] = setFn.mock.calls as [
+        unknown,
+        [string, () => ErrorHandler],
+      ];
+      const sut = serviceFn();
+      // Then
+      expect(sut).toBeInstanceOf(ErrorHandler);
+    });
+  });
+});

--- a/packages/public/error-handler/tests/tsconfig.json
+++ b/packages/public/error-handler/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@homer0/tsconfig/tsconfig.node.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "strict": true,
+    "noImplicitAny": true,
+    "resolveJsonModule": true
+  },
+  "include": ["./"]
+}

--- a/packages/public/error-handler/tsconfig.json
+++ b/packages/public/error-handler/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@homer0/tsconfig/tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "emitDecoratorMetadata": false,
+    "incremental": false
+  },
+  "include": ["src/**/*.ts", "tsup.config.ts"]
+}

--- a/packages/public/error-handler/tsup.config.ts
+++ b/packages/public/error-handler/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  sourcemap: true,
+  clean: true,
+  format: ['esm', 'cjs'],
+  legacyOutput: true,
+  dts: true,
+  bundle: false,
+});

--- a/utils/scripts/build
+++ b/utils/scripts/build
@@ -15,3 +15,4 @@ buildPkg package-info;
 buildPkg env-utils;
 buildPkg root-file;
 buildPkg simple-logger;
+buildPkg error-handler;


### PR DESCRIPTION
### What does this PR do?

It migrates the `errorHandler` module from `wootils` into its own package.

I also took the opportunity to move it to TypeScript.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```