### PR TITLE
Fix rule that decides if a tag renders as a column or in lines

### DIFF
--- a/packages/public/prettier-plugin-jsdoc/README.md
+++ b/packages/public/prettier-plugin-jsdoc/README.md
@@ -55,6 +55,7 @@ A [Prettier](https://prettier.io) plugin to format [JSDoc](https://jsdoc.app) bl
   - [Tag spacing: Between name and description](#tag-spacing-between-name-and-description)
   - [Space between description body and tags](#space-between-description-body-and-tags)
   - [Make sure descriptions are valid sentences](#make-sure-descriptions-are-valid-sentences)
+  - [Allow descriptions to be on different lines](#allow-descriptions-to-be-on-different-lines)
   - [Ignore tags for consistent columns](#ignore-tags-for-consistent-columns)
   - [Use an inline block for a single tag](#use-an-inline-block-for-a-single-tag)
 - [Extras](#extras)
@@ -766,7 +767,7 @@ If enabled, it will make sure descriptions start with an upper case letter and e
  */
 ```
 
-### Allow descriptions to be on different lines
+##### Allow descriptions to be on different lines
 
 | Option | Type | Default |
 | ------ | ---- | ------- |
@@ -809,6 +810,10 @@ A list of tags that are allowed to have their description on a new line.
 If enabled, when evaluating the rule for consistent columns, tags with description on a new line, allowed by `jsdocAllowDescriptionOnNewLinesForTags`, will be ignored.
 
 ##### Use an inline block for a single tag
+
+| Option                                    | Type    | Default |
+| ----------------------------------------- | ------- | ------- |
+| `jsdocUseInlineCommentForASingleTagBlock` | boolean | `false` |
 
 Whether or not to use a single line JSDoc block when there\'s only one tag.
 

--- a/packages/public/prettier-plugin-jsdoc/src/fns/constants.js
+++ b/packages/public/prettier-plugin-jsdoc/src/fns/constants.js
@@ -56,6 +56,14 @@ const getTagsWithDescriptionAsName = () => [
   'todo',
 ];
 /**
+ * Gets a list of tags that need to be in column format.
+ * Certain tags, when JSDoc is used with TypeScript, are required to be in columns format
+ * for the tsc to properly detect the types.
+ *
+ * @returns {string[]}
+ */
+const getTagsThatRequireColumns = () => ['template'];
+/**
  * This is almost the same as {@link getTagsWithDescriptionAsName}; the difference here is
  * that after putting together the `name` and the `description`, instead of saving the
  * result on `description`, it will be saved on `name`, as it will be better for the
@@ -73,6 +81,7 @@ const getSupportedLanguages = () => ['JavaScript', 'Flow', 'JSX', 'TSX', 'TypeSc
 
 module.exports.getTagsSynonyms = getTagsSynonyms;
 module.exports.getTagsWithDescriptionAsName = getTagsWithDescriptionAsName;
+module.exports.getTagsThatRequireColumns = getTagsThatRequireColumns;
 module.exports.getTagsWithNameAsDescription = getTagsWithNameAsDescription;
 module.exports.getSupportedLanguages = getSupportedLanguages;
-module.exports.provider = provider('constants');
+module.exports.provider = provider('constants', module.exports);

--- a/packages/public/prettier-plugin-jsdoc/test/e2e/fixtures/random-04.fixture.js
+++ b/packages/public/prettier-plugin-jsdoc/test/e2e/fixtures/random-04.fixture.js
@@ -1,0 +1,15 @@
+module.exports = {
+  printWidth: 50,
+};
+
+//# input
+
+/**
+ * @template {InputProps<Value>} [Props=React.ComponentProps<Input>]
+ */
+
+//# output
+
+/**
+ * @template {InputProps<Value>} [Props=React.ComponentProps<Input>]
+ */


### PR DESCRIPTION
### What does this PR do?

When validating if a tag should be rendered as a column or in multiple lines, I had a validation that was `!columnsWidth.description` and it was always validating to `true` even if there was no description... because `!-n` is `false` (:shamecube:).

Once I fixed the validation, I noticed that the same method was ignoring the fact that if the total of all the columns' width was more than the available width, it should render as multiple lines, so I fixed that too.

Finally, in order to properly fix #24, I added a new constant to specify tags that need to be rendered as columns for the tsc to detect the types. 

### How should it be tested manually?

I added a fixture with the issue from #24, so

```bash
yarn test
```
