### PR TITLE
fs-cache: rename cleanFiles and add missing doc

### DIFF
--- a/packages/public/fs-cache/README.md
+++ b/packages/public/fs-cache/README.md
@@ -163,6 +163,16 @@ await cache.purge({
 
 And just like with `remove`, you can also use `purgeMemory` or `purgeFs` to purge the entries from either cache.
 
+#### Cleaning the cache
+
+If you want to remove all entries, regardless of its expiration time, you can use the `clean` method:
+
+```ts
+await cache.clean();
+```
+
+Like `purge` and `remove`, you have the _cache-specific_ versions: `cleanMemory` and `cleanFs`.
+
 #### Jimple provider
 
 If your app uses a [Jimple container](https://npmjs.com/package/jimple), you can register `FsCache` as the `fsCache` service by using its provider:

--- a/packages/public/fs-cache/src/index.ts
+++ b/packages/public/fs-cache/src/index.ts
@@ -335,7 +335,7 @@ export class FsCache {
    *
    * @param options  Custom options to validate the files before removing them.
    */
-  async cleanFiles(options: FsCacheCleanFsOptions = {}): Promise<void> {
+  async cleanFs(options: FsCacheCleanFsOptions = {}): Promise<void> {
     const { extension = this.options.extension } = options;
     const dirPath = this.pathUtils.join(this.options.path);
     const dirContents = await fs.readdir(dirPath);
@@ -353,7 +353,7 @@ export class FsCache {
    * @param options  Custom options to validate the files before removing them.
    */
   clean(options: Omit<FsCacheCleanFsOptions, 'includeMemory'> = {}): Promise<void> {
-    return this.cleanFiles({
+    return this.cleanFs({
       ...options,
       includeMemory: true,
     });

--- a/packages/public/fs-cache/tests/index.test.ts
+++ b/packages/public/fs-cache/tests/index.test.ts
@@ -1271,7 +1271,7 @@ describe('FsCache', () => {
       });
     });
 
-    describe('cleanFiles', () => {
+    describe('cleanFs', () => {
       beforeEach(() => {
         resetFs();
         jest.useFakeTimers();
@@ -1359,7 +1359,7 @@ describe('FsCache', () => {
         const sut = new FsCache(sutOptions);
         const resultOneFileOne = await sut.use(entryOptionsOne);
         const resultOneFileTwo = await sut.use(entryOptionsTwo);
-        await sut.cleanFiles();
+        await sut.cleanFs();
         const resultTwoFileOne = await sut.use(entryOptionsOne);
         const resultTwoFileTwo = await sut.use(entryOptionsTwo);
         // Then
@@ -1447,7 +1447,7 @@ describe('FsCache', () => {
         const sut = new FsCache(sutOptions);
         const resultOneFileOne = await sut.use(entryOptionsOne);
         const resultOneFileTwo = await sut.use(entryOptionsTwo);
-        await sut.cleanFiles({
+        await sut.cleanFs({
           includeMemory: false,
           shouldRemove,
         });


### PR DESCRIPTION
### What does this PR do?

When I published the package, I forgot to document the `clean` methods, and while I was doing it, I noticed that the one for the fs was still using the old naming convention (at one point, everything related to fs was "files").

### How should it be tested manually?

```bash
npm test
# or
yarn test
```