### PR TITLE
Add Jest types to the TSConfig package

### DIFF
--- a/packages/personal/tsconfig/package.json
+++ b/packages/personal/tsconfig/package.json
@@ -14,6 +14,7 @@
   },
   "main": "tsconfig.json",
   "dependencies": {
+    "@types/jest": "^28.1.5",
     "@types/node": "^18.0.3",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6"

--- a/packages/public/api-utils/package.json
+++ b/packages/public/api-utils/package.json
@@ -24,7 +24,6 @@
   ],
   "devDependencies": {
     "@homer0/object-utils": "^1.0.1",
-    "@types/jest": "^28.1.4",
     "@types/urijs": "^1.19.19",
     "jest": "^28.1.2",
     "jest-fetch-mock": "^3.0.3",

--- a/packages/public/deep-assign/package.json
+++ b/packages/public/deep-assign/package.json
@@ -23,7 +23,6 @@
     "dist/"
   ],
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/deferred/package.json
+++ b/packages/public/deferred/package.json
@@ -23,7 +23,6 @@
     "dist/"
   ],
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/env-utils/package.json
+++ b/packages/public/env-utils/package.json
@@ -26,7 +26,6 @@
     "@homer0/jimple": "^1.0.1"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/error-handler/package.json
+++ b/packages/public/error-handler/package.json
@@ -27,7 +27,6 @@
     "@homer0/simple-logger": "^1.0.1"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/events-hub/package.json
+++ b/packages/public/events-hub/package.json
@@ -23,7 +23,6 @@
     "dist/"
   ],
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/extend-promise/package.json
+++ b/packages/public/extend-promise/package.json
@@ -23,7 +23,6 @@
     "dist/"
   ],
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/fs-cache/package.json
+++ b/packages/public/fs-cache/package.json
@@ -28,7 +28,6 @@
     "@homer0/path-utils": "^1.0.1"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/jimple/package.json
+++ b/packages/public/jimple/package.json
@@ -23,7 +23,6 @@
     "dist/"
   ],
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "jimple": "^1.5.0",
     "ts-jest": "^28.0.5",

--- a/packages/public/object-utils/package.json
+++ b/packages/public/object-utils/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@types/extend": "^3.0.1",
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/package-info/package.json
+++ b/packages/public/package-info/package.json
@@ -27,7 +27,6 @@
     "@homer0/path-utils": "^1.0.1"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "package-json-type": "^1.0.3",
     "ts-jest": "^28.0.5",

--- a/packages/public/path-utils/package.json
+++ b/packages/public/path-utils/package.json
@@ -26,7 +26,6 @@
     "@homer0/jimple": "^1.0.1"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/root-file/package.json
+++ b/packages/public/root-file/package.json
@@ -27,7 +27,6 @@
     "@homer0/path-utils": "^1.0.1"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/simple-config/package.json
+++ b/packages/public/simple-config/package.json
@@ -30,7 +30,6 @@
     "@homer0/root-file": "^1.0.1"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/simple-logger/package.json
+++ b/packages/public/simple-logger/package.json
@@ -29,7 +29,6 @@
     "colors": "^1.4.0"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "ts-jest": "^28.0.5",
     "tsup": "^6.1.3",

--- a/packages/public/simple-storage/package.json
+++ b/packages/public/simple-storage/package.json
@@ -24,7 +24,6 @@
   ],
   "devDependencies": {
     "@homer0/deep-assign": "^1.0.1",
-    "@types/jest": "^28.1.4",
     "jest": "^28.1.2",
     "jest-environment-jsdom": "^28.1.2",
     "ts-jest": "^28.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,10 +1840,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^28.1.4":
-  version "28.1.4"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-28.1.4.tgz#a11ee6c8fd0b52c19c9c18138b78bbcc201dad5a"
-  integrity sha512-telv6G5N7zRJiLcI3Rs3o+ipZ28EnE+7EvF0pSrt2pZOMnAVI/f+6/LucDxOvcBcTeTL3JMF744BbVQAVBUQRA==
+"@types/jest@^28.1.5":
+  version "28.1.5"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-28.1.5.tgz#4337404efa059adbf96c4ac53b28fdc0af514475"
+  integrity sha512-TLAC2zXxGnohSP3GxgIyJn7yrTeRPDEyVFyCY1NE2wzg392auI+69uk5EPGjUXuhkq/K208J/TWpLG7J8ebIEQ==
   dependencies:
     jest-matcher-utils "^28.0.0"
     pretty-format "^28.0.0"


### PR DESCRIPTION
### What does this PR do?

For some reason, I didn't notice before that the shared tsconfig didn't have the types for Jest, and that I was depending on them on every package xD.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```