### PR TITLE
Small features

### DIFF
--- a/packages/public/object-utils/README.md
+++ b/packages/public/object-utils/README.md
@@ -90,14 +90,22 @@ import { set } from '@homer0/object-utils';
 
 const target = {};
 
+console.log(set(target, 'some.prop.path', 'some-value'));
+// Will output { some: { prop: { path: 'some-value' } } }
+```
+
+And just like `get`, you can also use an options object:
+
+```ts
 console.log(
   set({
     target,
     path: 'some.prop.path',
     value: 'some-value',
+    pathDelimiter: '.',
   }),
 );
-// Will output { some: { prop: { path: 'some-value' } } }
+// Will also output { some: { prop: { path: 'some-value' } } }
 ```
 
 #### `extract`

--- a/packages/public/object-utils/README.md
+++ b/packages/public/object-utils/README.md
@@ -149,13 +149,20 @@ const target = {
   propTwo: '!!!',
 };
 
+console.log(remove(target, 'propOne.propOneSub'));
+// Will output { propTwo: '!!!' }
+```
+
+You can also use an options object instead of the target and the path:
+
+```ts
 console.log(
   remove({
     target,
     path: 'propOne.propOneSub',
   }),
 );
-// Will output { propTwo: '!!!' }
+// Will also output { propTwo: '!!!' }
 ```
 
 #### `flat`

--- a/packages/public/object-utils/README.md
+++ b/packages/public/object-utils/README.md
@@ -64,13 +64,21 @@ const obj = {
   propTwo: '!!!',
 };
 
+console.log(get(obj, 'propOne.propOneSub'));
+// Will output 'Charito!'
+```
+
+You can also use an options object to specify things like the `pathDelimiter`:
+
+```ts
 console.log(
   get({
     target: obj,
     path: 'propOne.propOneSub',
+    pathDelimiter: '.',
   }),
 );
-// Will output 'Charito!'
+// Will also output 'Charito!'
 ```
 
 #### `set`

--- a/packages/public/object-utils/src/fns/get.ts
+++ b/packages/public/object-utils/src/fns/get.ts
@@ -36,15 +36,32 @@ export type GetOptions = {
  *   // Will output 'Charito!'
  *
  */
-export const get = <T>(options: GetOptions): T | undefined => {
-  const { target, path, pathDelimiter = '.', failWithError = false } = options;
+function get<T>(options: GetOptions): T | undefined;
+function get<T>(options: unknown, path: string): T | undefined;
+function get<T>(options: GetOptions | unknown, path?: string): T | undefined {
+  let useOptions: GetOptions;
+  if (typeof path === 'string') {
+    useOptions = {
+      target: options,
+      path,
+    };
+  } else {
+    useOptions = options as GetOptions;
+  }
+
+  const {
+    target,
+    path: usePath,
+    pathDelimiter = '.',
+    failWithError = false,
+  } = useOptions;
   const useTarget = target as Record<string, unknown>;
-  const parts = path.split(pathDelimiter);
+  const parts = usePath.split(pathDelimiter);
   const first = parts.shift()!;
   let currentElement = useTarget[first] as Record<string, unknown>;
   if (typeof currentElement === 'undefined') {
     if (failWithError) {
-      throw new Error(`There's nothing on '${path}'`);
+      throw new Error(`There's nothing on '${usePath}'`);
     }
 
     return undefined;
@@ -71,4 +88,6 @@ export const get = <T>(options: GetOptions): T | undefined => {
   });
 
   return currentElement as T;
-};
+}
+
+export { get };

--- a/packages/public/object-utils/src/fns/remove.ts
+++ b/packages/public/object-utils/src/fns/remove.ts
@@ -42,16 +42,31 @@ export type RemoveOptions = {
  *   // Will output { propTwo: '!!!' }
  *
  */
-export const remove = <T = unknown>(options: RemoveOptions): T | undefined => {
+function remove<T = unknown>(options: RemoveOptions): T | undefined;
+function remove<T = unknown>(options: unknown, path: string): T | undefined;
+function remove<T = unknown>(
+  options: RemoveOptions | unknown,
+  path?: string,
+): T | undefined {
+  let useOptions: RemoveOptions;
+  if (typeof path === 'string') {
+    useOptions = {
+      target: options,
+      path,
+    };
+  } else {
+    useOptions = options as RemoveOptions;
+  }
+
   const {
     target,
-    path,
+    path: usePath,
     pathDelimiter = '.',
     cleanEmptyProperties = true,
     failWithError = false,
-  } = options;
+  } = useOptions;
 
-  const parts = path.split(pathDelimiter);
+  const parts = usePath.split(pathDelimiter);
   const last = parts.pop()!;
   const result = copy(target) as Record<string, unknown>;
   if (!parts.length) {
@@ -82,4 +97,6 @@ export const remove = <T = unknown>(options: RemoveOptions): T | undefined => {
   }
 
   return result as T;
-};
+}
+
+export { remove };

--- a/packages/public/object-utils/src/fns/set.ts
+++ b/packages/public/object-utils/src/fns/set.ts
@@ -38,15 +38,42 @@ export type SetOptions = {
  *   // Will output { some: { prop: { path: 'some-value' } } }
  *
  */
-export const set = <T = Record<string, unknown>>(options: SetOptions): T | undefined => {
-  const { target, path, value, pathDelimiter = '.', failWithError = false } = options;
+function set<T = Record<string, unknown>>(options: SetOptions): T | undefined;
+function set<T = Record<string, unknown>>(
+  options: SetOptions | unknown,
+  path: string,
+  value: unknown,
+): T | undefined;
+function set<T = Record<string, unknown>>(
+  options: SetOptions | unknown,
+  path?: string,
+  value?: unknown,
+): T | undefined {
+  let useOptions: SetOptions;
+  if (typeof path === 'string') {
+    useOptions = {
+      target: options,
+      path,
+      value,
+    };
+  } else {
+    useOptions = options as SetOptions;
+  }
+
+  const {
+    target,
+    path: usePath,
+    value: useValue,
+    pathDelimiter = '.',
+    failWithError = false,
+  } = useOptions;
   const result = copy(target) as Record<string, unknown>;
-  if (!path.includes(pathDelimiter)) {
-    result[path] = value;
+  if (!usePath.includes(pathDelimiter)) {
+    result[usePath] = useValue;
     return result as T;
   }
 
-  const parts = path.split(pathDelimiter);
+  const parts = usePath.split(pathDelimiter);
   const last = parts.pop();
   let currentElement = result;
   let currentPath = '';
@@ -75,8 +102,10 @@ export const set = <T = Record<string, unknown>>(options: SetOptions): T | undef
   if (foundInvalid) return undefined;
 
   if (result && last) {
-    currentElement[last] = value;
+    currentElement[last] = useValue;
   }
 
   return result as T | undefined;
-};
+}
+
+export { set };

--- a/packages/public/object-utils/tests/fns/get.test.ts
+++ b/packages/public/object-utils/tests/fns/get.test.ts
@@ -30,6 +30,22 @@ describe('get', () => {
     expect(result).toBe(name);
   });
 
+  it('should read a property using the short form', () => {
+    // Given
+    const name = 'Springfield';
+    const target = {
+      address: {
+        city: {
+          name,
+        },
+      },
+    };
+    // When
+    const result: string | undefined = get(target, 'address.city.name');
+    // Then
+    expect(result).toBe(name);
+  });
+
   it('should read a property from an object using a custom path', () => {
     // Given
     const name = 'Springfield';

--- a/packages/public/object-utils/tests/fns/remove.test.ts
+++ b/packages/public/object-utils/tests/fns/remove.test.ts
@@ -38,6 +38,23 @@ describe('remove', () => {
     expect(target).toEqual(targetCopy);
   });
 
+  it('should delete a property using the short form', () => {
+    // Given
+    const topElement = 'name';
+    const childElement = 'first';
+    const target = {
+      [topElement]: {
+        [childElement]: 'something',
+      },
+    };
+    const targetCopy = copy(target);
+    // When
+    const result = remove(target, `${topElement}.${childElement}`);
+    // Then
+    expect(result).toEqual({});
+    expect(target).toEqual(targetCopy);
+  });
+
   it('should delete a property from an object using a custom path', () => {
     // Given
     const topElement = 'name';

--- a/packages/public/object-utils/tests/fns/set.test.ts
+++ b/packages/public/object-utils/tests/fns/set.test.ts
@@ -55,6 +55,32 @@ describe('set', () => {
     expect(target).toEqual(targetCopy);
   });
 
+  it('should set a property using the short form', () => {
+    // Given
+    const topElement = 'person';
+    const target = {
+      [topElement]: {},
+    };
+    const targetCopy = copy(target);
+    const childElement = 'name';
+    const objPath = `${topElement}.${childElement}`;
+    const value = 'Rosario';
+    type ExpectedType = {
+      [topElement]: {
+        [childElement]: typeof value;
+      };
+    };
+    // When
+    const result: ExpectedType | undefined = set<ExpectedType>(target, objPath, value);
+    // Then
+    expect(result).toEqual({
+      [topElement]: {
+        [childElement]: value,
+      },
+    });
+    expect(target).toEqual(targetCopy);
+  });
+
   it('should set a property on an object using a custom path', () => {
     // Given
     const topElement = 'person';


### PR DESCRIPTION
### What does this PR do?

#### Simple config

When using `loadFromFIle`, you can now send a third parameter, `failWithError`, so the function won't fail if the file doesn't exist, just return `undefined`.

#### Object utils

I've been using the "new version" for a couple of days now, and I was getting sick of using `{ target: ..., path: ... }` for `get`, `set` and `remove`, so I added an overload on those methods to be able to use the old syntax:

- `get(target, path)`
- `set(target, path, value)`
- `remove(target, path)`

### How should it be tested manually?

```bash
yarn test
```
