### PR TITLE
Jimple: respect params on creator fns

### DIFF
--- a/packages/public/jimple/src/factories/factories.types.ts
+++ b/packages/public/jimple/src/factories/factories.types.ts
@@ -28,6 +28,7 @@ export type ResourceCreatorHandler<
 export type ResourceCreator<
   Name extends string,
   Key extends string,
-  Fn extends GenericCurriedFn,
-> = ((...args: Parameters<Fn>) => Resource<Name, Key, ReturnType<Fn>>) &
-  Resource<Name, Key, ReturnType<Fn>>;
+  CreatorFn extends GenericCurriedFn,
+  ResourceFn extends GenericFn,
+> = ((...args: Parameters<CreatorFn>) => Resource<Name, Key, ResourceFn>) &
+  Resource<Name, Key, ResourceFn>;

--- a/packages/public/jimple/src/factories/resourceCreatorFactory.ts
+++ b/packages/public/jimple/src/factories/resourceCreatorFactory.ts
@@ -57,7 +57,7 @@ export const resourceCreatorFactory =
     name: Name,
     key: Key,
     creatorFn: CreatorFn,
-  ): ResourceCreator<Name, Key, CreatorFn> => {
+  ): ResourceCreator<Name, Key, CreatorFn, ResourceFn> => {
     const fnToProxy: ResourceCreatorCurriedFn<Name, Key, CreatorFn> = (...args) => {
       const actualResource = creatorFn(...args) as ReturnType<CreatorFn>;
       return resourceFactory<ResFn>()(name, key, actualResource);
@@ -88,6 +88,7 @@ export const resourceCreatorFactory =
     return new Proxy(fnToProxy, handler) as unknown as ResourceCreator<
       Name,
       Key,
-      CreatorFn
+      CreatorFn,
+      ResourceFn
     >;
   };

--- a/packages/public/jimple/tests/factories/resourceCreatorFactory.test.ts
+++ b/packages/public/jimple/tests/factories/resourceCreatorFactory.test.ts
@@ -28,6 +28,7 @@ describe('resourceCreatorFactory', () => {
     // Then
     expect(sut[name]).toBe(true);
     expect(sut[key]).toBe(resourceFn);
+    expect(sut.apply).toEqual(expect.any(Function));
     // eslint-disable-next-line dot-notation
     expect(sut['invalid']).toBe(undefined);
     expect(creatorFn).toHaveBeenCalledTimes(1);
@@ -35,7 +36,7 @@ describe('resourceCreatorFactory', () => {
 
   it('should allow to configure the resource (multiple times)', () => {
     // Given
-    type ResourceFn = (arg0: string) => string;
+    type ResourceFn = (arg0?: string) => string;
     const name = 'providerCreator';
     const key = 'register';
     const finalResource = 'Batman';
@@ -72,5 +73,21 @@ describe('resourceCreatorFactory', () => {
     });
     expect(creatorFn).toHaveBeenCalledTimes(1);
     expect(creatorFn).toHaveBeenCalledWith(arg);
+  });
+
+  it.only('should create a resource creator x', () => {
+    // Given
+    type ResourceFn = (arg0: string) => string;
+    const name = 'providerCreator';
+    const key = 'register';
+    const resourceFn = jest.fn(() => 'Batman');
+    const creatorFn = jest.fn(() => resourceFn);
+    // When
+    const sut = resourceCreatorFactory<ResourceFn>()(name, key, creatorFn);
+    sut.register('something');
+    // Then
+    expect(sut[name]).toBe(true);
+    expect(sut[key]).toBe(resourceFn);
+    expect(creatorFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/public/jimple/tests/helpers/providerCreator.test.ts
+++ b/packages/public/jimple/tests/helpers/providerCreator.test.ts
@@ -7,9 +7,10 @@ describe('providerCreator', () => {
     const finalResource = 'Batman';
     const registerFn = jest.fn(() => finalResource);
     const creatorFn = jest.fn(() => registerFn);
+    const container = new Jimple();
     // When
     const sut = providerCreator(creatorFn);
-    const result = sut.register();
+    const result = sut.register(container);
     // Then
     expect(result).toBe(finalResource);
     expect(creatorFn).toHaveBeenCalledTimes(1);
@@ -25,10 +26,11 @@ describe('providerCreator', () => {
       registerFn = jest.fn(() => `${arg0}${finalResource}`);
       return registerFn;
     });
+    const container = new Jimple();
     // When
     const sut = providerCreator(creatorFn);
-    const configuredResult = sut(prefixArg).register();
-    const result = sut.register();
+    const configuredResult = sut(prefixArg).register(container);
+    const result = sut.register(container);
     // Then
     expect(configuredResult).toBe(`${prefixArg}${finalResource}`);
     expect(result).toBe(finalResource);


### PR DESCRIPTION
### What does this PR do?

While implementing a `providerCreator`, I noticed that due to inference, the resource fn returned by a creator fn wasn't respecting the parameters of the original type.

Let's assume this definition:

```ts
type ActionDoFn = (title: string) => string;
type ActionCreatorFn = GenericCurriedFn<ActionDoFn>;
const actionCreatorFactory = resourceCreatorFactory<ActionDoFn>();
const actionCreator = <CreatorFn extends ActionCreatorFn>(
  creator: CreatorFn,
) => actionCreatorFactory('action', 'do', creator);
```

Now this implementation:

```ts
const doFn = () => 'Something';
const creator = () => doFn;
const myAction = actionCreator(creator);
```

If I try and call the `do` fn with a parameter:

```ts
myAction.do('something');
// ...or
myAction().do('something');
```

I get an error, because the generic inside the factory is inferring that the return type of the creator, for this particular action, is `() => void`, so it shouldn't have parameters.

The fix was quite simple, instead of using `ReturnType<CreatorFn>` for the creator return fn, it now uses the `ResourceFn` that was sent to the factory when created.

### How should it be tested manually?

I had to fix a few tests do to this fix (I was registering providers without containers xD), so this time is for real:

```bash
yarn test
```