### PR TITLE
Disable sort-class-members for TypeScript ESLint config

### DIFF
--- a/packages/personal/eslint-plugin/rules/typescript.js
+++ b/packages/personal/eslint-plugin/rules/typescript.js
@@ -3,6 +3,7 @@ module.exports = {
     'import/extensions': 'off',
     'import/prefer-default-export': 'off',
     'lines-between-class-members': 'off',
+    'sort-class-members/sort-class-members': 'off',
     'no-useless-constructor': 'off',
     'no-unused-vars': 'off',
     'no-empty-function': 'off',


### PR DESCRIPTION
### What does this PR do?

The plugin doesn't detect TS scoping (private/protected), so it considers all of them as public.

### How should it be tested manually?

```bash
yarn test
```