### PR TITLE
fix(fs-cache): avoid double throw when there's an error

### DIFF
--- a/packages/public/fs-cache/src/index.ts
+++ b/packages/public/fs-cache/src/index.ts
@@ -160,9 +160,12 @@ export class FsCache {
         delete this.promises[key];
         return result;
       } catch (error) {
-        def.reject(error);
-        delete this.promises[key];
-        throw error;
+        setTimeout(() => {
+          def.reject(error);
+          delete this.promises[key];
+        }, 0);
+
+        return def.promise;
       }
     }
 
@@ -215,9 +218,11 @@ export class FsCache {
       delete this.promises[key];
       return value;
     } catch (error) {
-      def.reject(error);
-      delete this.promises[key];
-      throw error;
+      setTimeout(() => {
+        def.reject(error);
+        delete this.promises[key];
+      }, 0);
+      return def.promise;
     }
   }
   /**

--- a/packages/public/fs-cache/tests/index.test.ts
+++ b/packages/public/fs-cache/tests/index.test.ts
@@ -156,10 +156,12 @@ describe('FsCache', () => {
         };
         // When/Then
         const sut = new FsCache();
+        jest.useRealTimers();
         await Promise.all([
           expect(sut.use(options)).rejects.toThrow(message),
           expect(sut.use(options)).rejects.toThrow(message),
         ]);
+        jest.useFakeTimers();
       });
 
       it('should cache a value in the fs', async () => {
@@ -424,10 +426,12 @@ describe('FsCache', () => {
         fs.access.mockRejectedValueOnce(new Error(message));
         // When/Then
         const sut = new FsCache();
+        jest.useRealTimers();
         await Promise.all([
           expect(sut.use(options)).rejects.toThrow(message),
           expect(sut.use(options)).rejects.toThrow(message),
         ]);
+        jest.useFakeTimers();
       });
 
       it('should throw an error if the TTL is greater than the service max TTL', async () => {


### PR DESCRIPTION
### What does this PR do?

Because `fs-cache` uses deferred promises, doing `.reject` and `throw` would cause one to be properly handled, if handled, and the other to go outside the flow.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
