### PR TITLE
Fix small bugs on the JSDoc Prettier plugin

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,1 @@
-**/test/**/fixtures
+**/tests/**/fixtures

--- a/packages/public/prettier-plugin-jsdoc/src/fns/formatStringLiterals.js
+++ b/packages/public/prettier-plugin-jsdoc/src/fns/formatStringLiterals.js
@@ -62,7 +62,7 @@ const getReducer = (options) => {
  * @param {string} type  The type that will be used to find the string literals.
  * @returns {string[]}
  */
-const extractLiterals = (type) => R.match(/['"][\w\|\-\s'"]+['"](?: +)?/g, type);
+const extractLiterals = (type) => R.match(/['"][\w\|\-\s'"]+['"](?: +)?(?:$|\|)/g, type);
 /**
  * Formats the styling of string literals inside a type. If the type doesn't use string
  * literals, it will be returned without modification.

--- a/packages/public/prettier-plugin-jsdoc/src/fns/getParsers.js
+++ b/packages/public/prettier-plugin-jsdoc/src/fns/getParsers.js
@@ -76,10 +76,9 @@ const generateCommentData = (comment) => {
       start: { column },
     },
   } = comment;
-  const commentText = comment.value.replace(
-    /^(\s*\*\s*@[a-z]+){/gim,
-    (_, group) => `${group} {`,
-  );
+  const commentText = comment.value
+    .replace(/^(\s*\*\s*@[a-z]+){/gim, (_, group) => `${group} {`)
+    .replace(/(\s*\*\s*@[a-z]+\s+\{.*?\})\n(\s*\*)\s*(\w+)(?:\n|$)/gi, '$1 $3\n$2');
   const [block] = commentParser(`/*${commentText}*/`, {
     dotted_names: false,
     spacing: 'preserve',

--- a/packages/public/prettier-plugin-jsdoc/tests/e2e/fixtures/random-02.fixture.js
+++ b/packages/public/prettier-plugin-jsdoc/tests/e2e/fixtures/random-02.fixture.js
@@ -9,10 +9,28 @@ module.exports = {
  * @description don't transform this into a sentence
  */
 
+/**
+ * @typedef {{
+ *   'Sr No': number;
+ *   'Program name': string;
+ *   Seniority: number | null;
+ *   "Speaker's name": string;
+ * }} MemoriesRow
+ */
+
 //# output
 
 /**
  * don't transform this into a sentence
  *
  * @type {Object} Something
+ */
+
+/**
+ * @typedef {{
+ *   'Sr No': number;
+ *   'Program name': string;
+ *   Seniority: number | null;
+ *   "Speaker's name": string;
+ * }} MemoriesRow
  */

--- a/packages/public/prettier-plugin-jsdoc/tests/e2e/fixtures/random-05.fixture.js
+++ b/packages/public/prettier-plugin-jsdoc/tests/e2e/fixtures/random-05.fixture.js
@@ -1,0 +1,17 @@
+module.exports = {
+  printWidth: 90
+};
+
+//# input
+
+/**
+ * @typedef {import('./MemoriesAlgoliaRecord').MemoriesAlgoliaRecord}
+ * MemoriesAlgoliaRecord
+ */
+
+//# output
+
+/**
+ * @typedef {import('./MemoriesAlgoliaRecord').MemoriesAlgoliaRecord}
+ * MemoriesAlgoliaRecord
+ */


### PR DESCRIPTION
### What does this PR do?

#### Fix string literals issue

The RegExp used to detect string literals inside types was also detecting keys on objects:

```ts
/**
 * @typedef {{
 *   'Sr No': number;
 *   'Program name': string;
 *   Seniority: number | null;
 *   "Speaker's name": string;
 * }} MemoriesRow
 */
```

I fixed the RegExp by making sure the "string" needs to be followed by the end of the type, or a pipe.

Fixes #58 

#### Fix types with names on a different line

When you have a type like this one, and it goes beyond the `printWidth`/`jsdocPrintWidth`:

```ts
/**
 * @typedef {import('./MemoriesAlgoliaRecord').MemoriesAlgoliaRecord} MemoriesAlgoliaRecord
 */
```

The plugin will transform it in this:

```ts
/**
 * @typedef {import('./MemoriesAlgoliaRecord').MemoriesAlgoliaRecord}
 * MemoriesAlgoliaRecord
 */
```

The problem is that, the next time the plugin runs, it will think that the name is actually the block description, and depending on your config, it would move it above, or add it as the value `@description`.

To fix this, I made sure that if there's a type without name, and the next line is a single word, remove the line break, so the parser will correctly detect it as a name.

Fixes #59

### How should it be tested manually?

```bash
npm test
# or
yarn test
```
