### PR TITLE
Restore Prettier's plugin README with a link to the new page

### DIFF
--- a/packages/public/prettier-plugin-jsdoc/README.md
+++ b/packages/public/prettier-plugin-jsdoc/README.md
@@ -1,0 +1,3 @@
+# 𝍌 JSDoc plugin for Prettier
+
+🚀 This project has been moved into its own repository: [github.com/homer0/prettier-plugin-jsdoc](https://github.com/homer0/prettier-plugin-jsdoc)


### PR DESCRIPTION
### What does this PR do?

I found out that there are a lot of places linking to this directory directly, so I just restored the README and added a notice for the new repo.

### How should it be tested manually?

```bash
pnpm test
```