### PR TITLE
Allow config overwrite

### DIFF
--- a/packages/public/react-ssr-config/src/createConfig.ts
+++ b/packages/public/react-ssr-config/src/createConfig.ts
@@ -14,13 +14,20 @@ type ConfigOptions<Slices extends Record<string, ConfigSlice<string, GenericConf
    * The name of the config. If none is provider, the function will use a default name.
    */
   name?: string;
+  /**
+   * If true and there's already a config with the same name, it will be overwritten.
+   * This may be useful in development.
+   *
+   * @default false
+   */
+  overwrite?: boolean;
 };
 /**
  * Creates a config instance.
  *
  * @param options  The slices and/or customization options for the config.
  * @returns A new config instance.
- * @throws If a config with the same name already exists.
+ * @throws If a config with the same name already exists and `overwrite` is `false`.
  */
 function createConfig<Slices extends Record<string, ConfigSlice<string, GenericConfig>>>(
   options: Slices | ConfigOptions<Slices>,
@@ -32,10 +39,10 @@ function createConfig<Slices extends Record<string, ConfigSlice<string, GenericC
     useOptions = { slices: options as Slices };
   }
 
-  const { slices, name = DEFAULT_CONFIG_STORE } = useOptions;
+  const { slices, name = DEFAULT_CONFIG_STORE, overwrite = false } = useOptions;
 
   const store = getStore();
-  if (store[name]) {
+  if (store[name] && !overwrite) {
     throw new Error(`The config "${name}" already exists`);
   }
 

--- a/packages/public/react-ssr-config/tests/createConfig.test.ts
+++ b/packages/public/react-ssr-config/tests/createConfig.test.ts
@@ -65,6 +65,21 @@ describe('Config', () => {
     expect(sliceConfig).toBe(dummySliceConfig);
   });
 
+  it('should overwrite an existing config and not throw', () => {
+    // Given
+    const slices = getSlices();
+    // When
+    const firstConfig = createConfig(slices);
+    const secondConfig = createConfig({
+      slices,
+      overwrite: true,
+    });
+    // Then
+    expect(firstConfig).toBeInstanceOf(Config);
+    expect(secondConfig).toBeInstanceOf(Config);
+    expect(firstConfig).not.toBe(secondConfig);
+  });
+
   it('should throw when another config was created with the same name', () => {
     // Given
     const slices = getSlices();


### PR DESCRIPTION
### What does this PR do?

I found that sometimes, when working on projects with HMR, having the "unique name validation" makes it throw, so I added an option to allow for it to be overwritten.

### How should it be tested manually?

```bash
pnpm test
```