### PR TITLE
ESLint plugin: add 100 as ignored magic number

### DIFF
--- a/packages/personal/eslint-plugin/rules/best-practices.js
+++ b/packages/personal/eslint-plugin/rules/best-practices.js
@@ -5,7 +5,7 @@ module.exports = {
     'no-magic-numbers': [
       'error',
       {
-        ignore: [0, 1, -1, 60, 1000],
+        ignore: [0, 1, -1, 60, 100, 1000],
         ignoreArrayIndexes: true,
         enforceConst: false,
         detectObjects: false,


### PR DESCRIPTION
### What does this PR do?

After a lot of work with percentages, I decided to ignore `100` for `no-magic-numbers`.

### How should it be tested manually?

```bash
pnpm test
```