### PR TITLE
fix(eslint-plugin): remove forOf instead of forIn from exception

### DIFF
--- a/packages/personal/eslint-plugin/rules/style.js
+++ b/packages/personal/eslint-plugin/rules/style.js
@@ -16,9 +16,9 @@ module.exports = {
     'no-restricted-syntax': [
       'error',
       {
-        selector: 'ForOfStatement',
+        selector: 'ForInStatement',
         message:
-          'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
+          'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
       },
       {
         selector: 'LabeledStatement',


### PR DESCRIPTION
### What does this PR do?

Follow up for #90 - I removed `forIn` instead of `forOf`.

### How should it be tested manually?

```bash
pnpm test
```
